### PR TITLE
fix(ci): skip publish job when no packages built

### DIFF
--- a/.github/workflows/main-casaos-official.yml
+++ b/.github/workflows/main-casaos-official.yml
@@ -18,6 +18,8 @@ jobs:
     name: Build CasaOS Official Packages
     runs-on: ubuntu-latest
     outputs:
+      # TEMPORARY: This output is needed during implementation phase when sources may not exist yet.
+      # Once all sources are implemented, this will always be 'true' and can be removed.
       has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
@@ -29,6 +31,10 @@ jobs:
         with:
           source: casaos-official
 
+      # TEMPORARY: This check is needed during implementation phase.
+      # The build-deb action skips building when sources don't exist yet (intentional design).
+      # This step detects that case and prevents artifact upload/publish failures.
+      # Remove this step once sources/casaos-official/ is fully implemented and always contains apps.
       - name: Check if packages were built
         id: check-packages
         run: |
@@ -40,6 +46,8 @@ jobs:
             echo "::notice::No packages built (source not yet implemented)"
           fi
 
+      # TEMPORARY: This conditional prevents upload failures when no packages were built.
+      # Remove the 'if' condition once sources are always present and packages are always built.
       - name: Upload build artifacts
         if: steps.check-packages.outputs.has-packages == 'true'
         uses: actions/upload-artifact@v4
@@ -55,6 +63,10 @@ jobs:
     name: Publish to Unstable Channel
     runs-on: ubuntu-latest
     needs: build
+    # TEMPORARY: This conditional is needed during implementation phase when sources may not exist.
+    # It prevents this job from running (and failing) when the build job didn't produce packages.
+    # Remove this 'if' condition once sources/casaos-official/ is fully implemented.
+    # At that point, the build job will always produce packages and this job should always run.
     if: needs.build.outputs.has-packages == 'true'
     # TODO: Implement when shared-workflows publish-unstable.yml is available
     # For now, this job is a placeholder


### PR DESCRIPTION
## Summary

Fixes the failing Main workflow that occurred after PR #24 was merged. The publish-unstable job was trying to download artifacts that were never created when the build job skipped package creation (e.g., when source directory doesn't exist yet).

## Changes

- Added `has-packages` output to build job to indicate if packages were actually built
- Added check step before artifact upload to detect if .deb files exist
- Made upload step conditional on packages existing
- Made publish-unstable job conditional on `has-packages` output
- Removed redundant package existence check in publish job (no longer needed since job is conditional)

## Behavior

**Before**: Workflow failed when sources weren't implemented yet because publish job tried to download non-existent artifacts

**After**: 
- When sources don't exist: Build job completes successfully, publish job is skipped
- When sources exist and packages are built: Both jobs run as expected

## Test Plan

- [x] Verify workflow syntax is valid
- [ ] Confirm build job runs and outputs has-packages=false when sources don't exist
- [ ] Confirm publish job is skipped when has-packages=false
- [ ] Confirm both jobs run when packages are actually built (future test when sources are implemented)

Fixes: https://github.com/hatlabs/halos-imported-containers/actions/runs/19771377169

🤖 Generated with [Claude Code](https://claude.com/claude-code)