### PR TITLE
feat(casaos-official): add 147 converted CasaOS apps

### DIFF
--- a/sources/casaos-official/apps/2fauth/config.yml
+++ b/sources/casaos-official/apps/2fauth/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/2fauth/docker-compose.yml
+++ b/sources/casaos-official/apps/2fauth/docker-compose.yml
@@ -1,0 +1,12 @@
+name: 2fauth
+services:
+  2fauth:
+    image: 2fauth/2fauth:5.4.3
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    volumes:
+    - source: /AppData/$AppID
+      target: /2fauth
+      type: bind

--- a/sources/casaos-official/apps/2fauth/metadata.yaml
+++ b/sources/casaos-official/apps/2fauth/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: utils
+description: A web app to manage your Two-Factor Authentication (2FA) accounts and...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/2FAuth/icon.png
+license: Unknown
+long_description: 'A web app to manage your Two-Factor Authentication (2FA) accounts
+  and generate their security codes
+
+
+  2FAuth is a web based self-hosted alternative to One Time Passcode (OTP) generators
+  like Google Authenticator, designed for both mobile and desktop.'
+maintainer: Bubka <auto-converted@casaos.io>
+name: 2fauth
+package_name: casaos-2fauth-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/2FAuth/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/2FAuth/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/2FAuth/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/actualbudget/config.yml
+++ b/sources/casaos-official/apps/actualbudget/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/actualbudget/docker-compose.yml
+++ b/sources/casaos-official/apps/actualbudget/docker-compose.yml
@@ -1,0 +1,12 @@
+name: actualbudget
+services:
+  actualbudget:
+    image: actualbudget/actual-server:25.7.1
+    ports:
+    - protocol: tcp
+      published: 15006
+      target: 5006
+    volumes:
+    - source: /AppData/$AppID
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/actualbudget/metadata.yaml
+++ b/sources/casaos-official/apps/actualbudget/metadata.yaml
@@ -1,0 +1,74 @@
+architecture: all
+debian_section: misc
+description: Privacy-first finance app with envelope budgeting and multi-device sync.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/icon.png
+license: Unknown
+long_description: 'Actual Budget is a fast, privacy-focused finance management app
+  using local-first envelope budgeting, ensuring full control over data. Its intuitive
+  interface supports offline use, with multi-device sync and optional end-to-end encryption,
+  delivering a secure, efficient financial management experience, ideal for users
+  seeking clear financial oversight.
+
+
+  The app''s core features include envelope budgeting based on real income, rapid
+  transaction handling, and intuitive financial reporting. It helps users track spending
+  and monitor monthly savings clearly, with a streamlined transaction editor for quick
+  categorization, split transactions, and transfers. Built-in net worth and cash flow
+  reports provide financial insights, and a custom report engine allows tailored reports
+  for specific needs. Undo and redo functionality ensures users can easily correct
+  mistakes, maintaining operational flexibility.
+
+
+  It integrates bank accounts via goCardless (EU/UK) or SimpleFIN (US/Canada), supports
+  multi-device syncing for data privacy, and enables importing transaction data from
+  YNAB4, nYNAB, and QIF, OFX, QFX, CAMT.053, CSV files, simplifying migration of existing
+  financial records. Community documentation enhances usability, and the app''s simple
+  operation and high flexibility deliver a modern finance management solution.
+
+
+  **Key Features:**
+
+  - Privacy-focused personal finance management
+
+  - Envelope budgeting methodology
+
+  - Multi-device synchronization
+
+  - End-to-end encryption support
+
+  - Local data ownership
+
+  - Fast and responsive interface
+
+  - Open source and self-hosted
+
+  - Bank account synchronization
+
+  - Detailed financial reporting
+
+  - Budget tracking and analysis
+
+
+  **Learn More:**
+
+  - [Actual Budget Official Website](https://actualbudget.org)
+
+  - [Actual Budget GitHub Repository](https://github.com/actualbudget/actual)
+
+  - [Actual Budget Docker Image](https://hub.docker.com/r/actualbudget/actual-server)
+
+  '
+maintainer: ActualBudget <auto-converted@casaos.io>
+name: actualbudget
+package_name: casaos-actualbudget-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ActualBudget/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/adguard-home/config.yml
+++ b/sources/casaos-official/apps/adguard-home/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/adguard-home/docker-compose.yml
+++ b/sources/casaos-official/apps/adguard-home/docker-compose.yml
@@ -1,0 +1,27 @@
+name: adguard-home
+services:
+  adguard-home:
+    image: adguard/adguardhome:v0.107.61
+    ports:
+    - protocol: tcp
+      published: 531
+      target: 53
+    - protocol: udp
+      published: 531
+      target: 53
+    - protocol: tcp
+      published: 3001
+      target: 3000
+    - protocol: tcp
+      published: 853
+      target: 853
+    - protocol: udp
+      published: 784
+      target: 784
+    volumes:
+    - source: /AppData/$AppID/opt/adguardhome/work
+      target: /opt/adguardhome/work
+      type: bind
+    - source: /AppData/$AppID/opt/adguardhome/conf
+      target: /opt/adguardhome/conf
+      type: bind

--- a/sources/casaos-official/apps/adguard-home/metadata.yaml
+++ b/sources/casaos-official/apps/adguard-home/metadata.yaml
@@ -1,0 +1,39 @@
+architecture: all
+debian_section: net
+description: Blocking ads & tracking Network-widly
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/icon.png
+license: Unknown
+long_description: 'Difference from Traditional Ad Blockers. Unlike traditional ad-blocking
+  plugins that work only on individual devices, AdGuard Home offers a network-wide
+  solution. By setting it up, you can block ads and trackers across all your home
+  devices without needing to install any additional software on each device. This
+  means comprehensive protection with minimal effort.
+
+
+  How AdGuard Home Works and How to Use It. AdGuard Home functions as a DNS server
+  that reroutes tracking domains to a "black hole," effectively preventing your devices
+  from connecting to these servers. This blocks ads and trackers not only on your
+  computer but also on your smartphone and smart home devices. To start using AdGuard
+  Home, deploy it on your device, then change the DNS address assigned by DHCP on
+  your router to the IP address of your AdGuard Home server.
+
+
+  Benefits of Deploying AdGuard Home on Zima Private Cloud. Deploying AdGuard Home
+  on a Zima device simplifies network-wide ad and tracker blocking, providing a seamless
+  and secure browsing experience for all your home devices. With Zima, you gain the
+  flexibility to monitor network activity and create custom filtering rules tailored
+  to your needs.
+
+  '
+maintainer: AdguardTeam <auto-converted@casaos.io>
+name: adguard-home
+package_name: casaos-adguard-home-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AdGuardHome/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/adminer/config.yml
+++ b/sources/casaos-official/apps/adminer/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/adminer/docker-compose.yml
+++ b/sources/casaos-official/apps/adminer/docker-compose.yml
@@ -1,0 +1,8 @@
+name: adminer
+services:
+  adminer:
+    image: adminer:5.4.1
+    ports:
+    - protocol: tcp
+      published: 8080
+      target: 8080

--- a/sources/casaos-official/apps/adminer/metadata.yaml
+++ b/sources/casaos-official/apps/adminer/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: database
+description: Database management in a single PHP file
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Adminer/icon.png
+license: Unknown
+long_description: Adminer (formerly phpMinAdmin) is a full-featured database management
+  tool written in PHP. Conversely to phpMyAdmin, it consist of a single file ready
+  to deploy to the target server. Adminer is available for MySQL, PostgreSQL, SQLite,
+  MS SQL, Oracle, Firebird, SimpleDB, Elasticsearch and MongoDB.
+maintainer: Jakub Vrána <auto-converted@casaos.io>
+name: adminer
+package_name: casaos-adminer-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Adminer/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Adminer/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Adminer/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/albyhub/config.yml
+++ b/sources/casaos-official/apps/albyhub/config.yml
@@ -1,0 +1,54 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: '002'
+    description: ''
+    id: UMASK
+    label: UMASK
+    required: false
+    type: string
+  - default: 'True'
+    description: ''
+    id: LOG_EVENTS
+    label: LOG_EVENTS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: /data/albyhub
+    description: ''
+    id: WORK_DIR
+    label: WORK_DIR
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/albyhub/docker-compose.yml
+++ b/sources/casaos-official/apps/albyhub/docker-compose.yml
@@ -1,0 +1,19 @@
+name: albyhub
+services:
+  albyhub:
+    environment:
+      LOG_EVENTS: ${LOG_EVENTS}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+      UMASK: ${UMASK}
+      WORK_DIR: ${WORK_DIR}
+    image: ghcr.io/getalby/hub:v1.20.0
+    ports:
+    - protocol: tcp
+      published: 58000
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/albyhub/metadata.yaml
+++ b/sources/casaos-official/apps/albyhub/metadata.yaml
@@ -1,0 +1,45 @@
+architecture: all
+debian_section: misc
+description: Self-custodial Bitcoin Lightning wallet with integrated node and app...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/getAlby/hub@master/frontend/public/icon-512.png
+license: Unknown
+long_description: 'Self-custodial Bitcoin Lightning wallet with integrated node and
+  app connections.
+
+
+  Alby Hub is an open-source, self-custodial Bitcoin Lightning wallet, with the easiest-to-use
+  Lightning Network node for everyone.
+
+  Whether you''re an individual, creator, or developer, Alby Hub is your centre for
+  seamless Bitcoin payments.
+
+  Effortlessly connect to a variety of apps like the Alby Browser Extension or Alby
+  Go mobile app, create sub-wallets for family and friends, and take full control
+  of your funds—all within an intuitive interface and developer-ready APIs.
+
+
+  **USEFUL LINKS**
+
+  - [Source Repository](https://github.com/getAlby/hub)
+
+  - [Support](https://support.getalby.com/)
+
+  - [Marketing Site](https://albyhub.com/)
+
+  - [Community of users and developers](https://discord.getalby.com)
+
+  - [Feedback Board, feature requests, bug reports[(https://feedback.getalby.com)
+
+  '
+maintainer: Unknown <auto-converted@casaos.io>
+name: albyhub
+package_name: casaos-albyhub-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/getAlby/umbrel-community-app-store@master/alby-albyhub/images/node.png
+- https://cdn.jsdelivr.net/gh/getAlby/umbrel-community-app-store@master/alby-albyhub/images/store.png
+- https://cdn.jsdelivr.net/gh/getAlby/umbrel-community-app-store@master/alby-albyhub/images/wallet.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/alist-sync/config.yml
+++ b/sources/casaos-official/apps/alist-sync/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: Asia/Shanghai
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/alist-sync/docker-compose.yml
+++ b/sources/casaos-official/apps/alist-sync/docker-compose.yml
@@ -1,0 +1,14 @@
+name: alist-sync
+services:
+  alist-sync:
+    environment:
+      TZ: ${TZ}
+    image: xjxjin/alist-sync:1.1.5
+    ports:
+    - protocol: tcp
+      published: 52441
+      target: 52441
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /app/data
+      type: bind

--- a/sources/casaos-official/apps/alist-sync/metadata.yaml
+++ b/sources/casaos-official/apps/alist-sync/metadata.yaml
@@ -1,0 +1,25 @@
+architecture: all
+debian_section: net
+description: An Alist storage synchronization tool based on the Web interface.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/icon.png
+license: Unknown
+long_description: 'Alist-Sync is a storage synchronization tool based on the Web interface.
+  It can achieve data synchronization and mutual backup among multiple network disks,
+  and also has practical functions such as multi-task management, scheduled synchronization
+  and difference handling.
+
+  '
+maintainer: xjxjin <auto-converted@casaos.io>
+name: alist-sync
+package_name: casaos-alist-sync-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist-Sync/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/alist/config.yml
+++ b/sources/casaos-official/apps/alist/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/alist/docker-compose.yml
+++ b/sources/casaos-official/apps/alist/docker-compose.yml
@@ -1,0 +1,12 @@
+name: alist
+services:
+  alist:
+    image: xhofe/alist:v3.40.0
+    ports:
+    - protocol: tcp
+      published: 5244
+      target: 5244
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /opt/alist/data
+      type: bind

--- a/sources/casaos-official/apps/alist/metadata.yaml
+++ b/sources/casaos-official/apps/alist/metadata.yaml
@@ -1,0 +1,38 @@
+architecture: all
+debian_section: net
+description: Mount your cloud drive on your home NAS
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/icon.png
+license: Unknown
+long_description: 'Alist transforms how you manage and access your files at home,
+  whether on your TV, phone, or any other device. Unlike traditional cloud storage,
+  Alist offers a unified experience across multiple platforms, making it a breeze
+  to keep your media and documents at your fingertips.
+
+
+  With features like easy installation, support for multiple storage providers (local,
+  Aliyundrive, Onedrive, Google Drive), WebDAV support, dark mode, protected routes
+  with password authentication, file previews for videos, audio, office files, PDFs,
+  code, images, package and batch downloads, single sign-on, offline torrent downloads,
+  file encryption, and additional tools like a text editor and Cloudflare workers
+  proxy, Alist ensures a seamless and secure file management experience.
+
+
+  Deploying Alist on private cloud devices like Zima brings unmatched convenience
+  with multi-device access, ensuring your files are always within reach and secure,
+  no matter where you are.
+
+  '
+maintainer: Xhofe <auto-converted@casaos.io>
+name: alist
+package_name: casaos-alist-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Alist/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/anaconda3/config.yml
+++ b/sources/casaos-official/apps/anaconda3/config.yml
@@ -1,0 +1,24 @@
+groups:
+- description: null
+  fields:
+  - default: C.UTF-8
+    description: ''
+    id: LANG
+    label: LANG
+    required: false
+    type: string
+  - default: C.UTF-8
+    description: ''
+    id: LC_ALL
+    label: LC_ALL
+    required: false
+    type: string
+  - default: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    description: ''
+    id: PATH
+    label: PATH
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/anaconda3/docker-compose.yml
+++ b/sources/casaos-official/apps/anaconda3/docker-compose.yml
@@ -1,0 +1,21 @@
+name: anaconda3
+services:
+  anaconda3:
+    command:
+    - /bin/bash
+    - -c
+    - conda install -c conda-forge jupyterlab -y --quiet && jupyter lab --notebook-dir=/opt/notebooks
+      --ip='*' --port=8888 --no-browser --allow-root
+    environment:
+      LANG: ${LANG}
+      LC_ALL: ${LC_ALL}
+      PATH: ${PATH}
+    image: continuumio/anaconda3:2024.10-1
+    ports:
+    - protocol: tcp
+      published: 8888
+      target: 8888
+    volumes:
+    - source: /AppData/$AppID/notebooks
+      target: /opt/notebooks
+      type: bind

--- a/sources/casaos-official/apps/anaconda3/metadata.yaml
+++ b/sources/casaos-official/apps/anaconda3/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: misc
+description: Your machine learning Env work with Jupyter Lab
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Anaconda3/icon.png
+license: Unknown
+long_description: Your machine learning Env work with Jupyter Lab
+maintainer: LisonEvf <auto-converted@casaos.io>
+name: anaconda3
+package_name: casaos-anaconda3-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Anaconda3/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Anaconda3/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Anaconda3/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/anythingllm/config.yml
+++ b/sources/casaos-official/apps/anythingllm/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/anythingllm/docker-compose.yml
+++ b/sources/casaos-official/apps/anythingllm/docker-compose.yml
@@ -1,0 +1,12 @@
+name: anythingllm
+services:
+  anythingllm:
+    image: mintplexlabs/anythingllm
+    ports:
+    - protocol: tcp
+      published: 3051
+      target: 3001
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/storage
+      target: /app/server/storage
+      type: bind

--- a/sources/casaos-official/apps/anythingllm/metadata.yaml
+++ b/sources/casaos-official/apps/anythingllm/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: comm
+description: The all-in-one AI application.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AnythingLLM/icon.png
+license: Unknown
+long_description: AnythingLLM is the easiest to use, all-in-one AI application that
+  can do RAG, AI Agents, and much more with no code or infrastructure headaches.
+maintainer: Mintplex Labs <auto-converted@casaos.io>
+name: anythingllm
+package_name: casaos-anythingllm-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/AnythingLLM/screenshot-1.gif
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/archivebox/config.yml
+++ b/sources/casaos-official/apps/archivebox/config.yml
@@ -1,0 +1,118 @@
+groups:
+- description: null
+  fields:
+  - default: casaos
+    description: Admin Username for Authentication
+    id: ADMIN_USERNAME
+    label: ADMIN_USERNAME
+    required: false
+    type: string
+  - default: casaos
+    description: Admin Password for Authentication
+    id: ADMIN_PASSWORD
+    label: ADMIN_PASSWORD
+    required: false
+    type: password
+  - default: SomeSecretPassword
+    description: Search Backend Password
+    id: SEARCH_BACKEND_PASSWORD
+    label: SEARCH_BACKEND_PASSWORD
+    required: false
+    type: password
+  - default: SomeSecretPassword
+    description: Search Backend Password
+    id: SEARCH_BACKEND_PASSWORD
+    label: SEARCH_BACKEND_PASSWORD
+    required: false
+    type: password
+  - default: SomeSecretPassword
+    description: Search Backend Password
+    id: SEARCH_BACKEND_PASSWORD
+    label: SEARCH_BACKEND_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: '*'
+    description: Allowed Hosts for Web Interface
+    id: ALLOWED_HOSTS
+    label: ALLOWED_HOSTS
+    required: false
+    type: string
+  - default: '*'
+    description: Trusted Origins for CSRF Protection
+    id: CSRF_TRUSTED_ORIGINS
+    label: CSRF_TRUSTED_ORIGINS
+    required: false
+    type: string
+  - default: 'True'
+    description: Allow Public Access to Snapshot List
+    id: PUBLIC_INDEX
+    label: PUBLIC_INDEX
+    required: false
+    type: string
+  - default: 'True'
+    description: Allow Public Access to Snapshot Content
+    id: PUBLIC_SNAPSHOTS
+    label: PUBLIC_SNAPSHOTS
+    required: false
+    type: string
+  - default: 'False'
+    description: Allow Public URL Submission
+    id: PUBLIC_ADD_VIEW
+    label: PUBLIC_ADD_VIEW
+    required: false
+    type: string
+  - default: sonic
+    description: Search Backend Engine
+    id: SEARCH_BACKEND_ENGINE
+    label: SEARCH_BACKEND_ENGINE
+    required: false
+    type: string
+  - default: archivebox_sonic
+    description: Search Backend Host Name
+    id: SEARCH_BACKEND_HOST_NAME
+    label: SEARCH_BACKEND_HOST_NAME
+    required: false
+    type: string
+  - default: '120'
+    description: Timeout for Download Operations
+    id: TIMEOUT
+    label: TIMEOUT
+    required: false
+    type: integer
+  - default: sonic
+    description: Search Backend Engine
+    id: SEARCH_BACKEND_ENGINE
+    label: SEARCH_BACKEND_ENGINE
+    required: false
+    type: string
+  - default: archivebox_sonic
+    description: Search Backend Host Name
+    id: SEARCH_BACKEND_HOST_NAME
+    label: SEARCH_BACKEND_HOST_NAME
+    required: false
+    type: string
+  - default: '1920'
+    description: Display Width in Pixels
+    id: DISPLAY_WIDTH
+    label: DISPLAY_WIDTH
+    required: false
+    type: string
+  - default: '1080'
+    description: Display Height in Pixels
+    id: DISPLAY_HEIGHT
+    label: DISPLAY_HEIGHT
+    required: false
+    type: string
+  - default: 'no'
+    description: Run XTerm Terminal
+    id: RUN_XTERM
+    label: RUN_XTERM
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/archivebox/docker-compose.yml
+++ b/sources/casaos-official/apps/archivebox/docker-compose.yml
@@ -1,0 +1,57 @@
+name: archivebox
+services:
+  archivebox:
+    environment:
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      ADMIN_USERNAME: ${ADMIN_USERNAME}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS}
+      PUBLIC_ADD_VIEW: ${PUBLIC_ADD_VIEW}
+      PUBLIC_INDEX: ${PUBLIC_INDEX}
+      PUBLIC_SNAPSHOTS: ${PUBLIC_SNAPSHOTS}
+      SEARCH_BACKEND_ENGINE: ${SEARCH_BACKEND_ENGINE}
+      SEARCH_BACKEND_HOST_NAME: ${SEARCH_BACKEND_HOST_NAME}
+      SEARCH_BACKEND_PASSWORD: ${SEARCH_BACKEND_PASSWORD}
+    image: archivebox/archivebox:0.7.3
+    ports:
+    - protocol: tcp
+      published: 18010
+      target: 8000
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+  archivebox_novnc:
+    environment:
+      DISPLAY_HEIGHT: ${DISPLAY_HEIGHT}
+      DISPLAY_WIDTH: ${DISPLAY_WIDTH}
+      RUN_XTERM: ${RUN_XTERM}
+    image: theasp/novnc:latest
+    ports:
+    - protocol: tcp
+      published: 18082
+      target: 8080
+  archivebox_scheduler:
+    command:
+    - schedule
+    - --foreground
+    - --update
+    - --every=day
+    environment:
+      SEARCH_BACKEND_ENGINE: ${SEARCH_BACKEND_ENGINE}
+      SEARCH_BACKEND_HOST_NAME: ${SEARCH_BACKEND_HOST_NAME}
+      SEARCH_BACKEND_PASSWORD: ${SEARCH_BACKEND_PASSWORD}
+      TIMEOUT: ${TIMEOUT}
+    image: archivebox/archivebox:0.7.3
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+  archivebox_sonic:
+    environment:
+      SEARCH_BACKEND_PASSWORD: ${SEARCH_BACKEND_PASSWORD}
+    image: archivebox/sonic:1.4.9
+    volumes:
+    - source: /AppData/$AppID/data/sonic
+      target: /var/lib/sonic/store
+      type: bind

--- a/sources/casaos-official/apps/archivebox/metadata.yaml
+++ b/sources/casaos-official/apps/archivebox/metadata.yaml
@@ -1,0 +1,59 @@
+architecture: all
+debian_section: utils
+description: Self-hosted internet archiving solution
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ArchiveBox/icon.png
+license: Unknown
+long_description: 'ArchiveBox is a powerful, self-hosted internet archiving solution
+  that allows you to create your own personal archive of web pages, PDFs, videos,
+  and more. It functions as a personal internet archive, saving content in multiple
+  formats for long-term preservation.
+
+
+  The system consists of multiple components:
+
+  - **ArchiveBox**: The main application providing the web interface and archiving
+  capabilities
+
+  - **Sonic**: A fast search backend for full-text search across archived content
+
+  - **ArchiveBox Scheduler**: A background service for scheduled archiving tasks
+
+  - **NoVNC**: A web-based VNC client for browser-based archiving
+
+
+  **Key Features:**
+
+  - Save web pages in multiple formats (HTML, PDF, screenshots, etc.)
+
+  - Full-text search across all archived content
+
+  - Scheduled archiving of websites and RSS feeds
+
+  - Browser-based archiving with NoVNC
+
+  - User authentication and access control
+
+  - Extract and save media files (videos, audio, PDFs, etc.)
+
+
+  **Learn More:**
+
+  - [ArchiveBox Official Website](https://archivebox.io)
+
+  - [ArchiveBox GitHub Repository](https://github.com/ArchiveBox/ArchiveBox)
+
+  - [ArchiveBox Documentation](https://github.com/ArchiveBox/ArchiveBox/wiki)
+
+  '
+maintainer: ArchiveBox <auto-converted@casaos.io>
+name: archivebox
+package_name: casaos-archivebox-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ArchiveBox/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ArchiveBox/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ArchiveBox/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/audiobookshelf/config.yml
+++ b/sources/casaos-official/apps/audiobookshelf/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/audiobookshelf/docker-compose.yml
+++ b/sources/casaos-official/apps/audiobookshelf/docker-compose.yml
@@ -1,0 +1,21 @@
+name: audiobookshelf
+services:
+  audiobookshelf:
+    image: ghcr.io/advplyr/audiobookshelf:2.30.0
+    ports:
+    - protocol: tcp
+      published: 13378
+      target: 80
+    volumes:
+    - source: /Media/Audiobooks
+      target: /audiobooks
+      type: bind
+    - source: /Media/Podcasts
+      target: /podcasts
+      type: bind
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /AppData/$AppID/metadata
+      target: /metadata
+      type: bind

--- a/sources/casaos-official/apps/audiobookshelf/metadata.yaml
+++ b/sources/casaos-official/apps/audiobookshelf/metadata.yaml
@@ -1,0 +1,73 @@
+architecture: all
+debian_section: video
+description: Audiobookshelf is a self-hosted audiobook and podcast server.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Audiobookshelf/icon.png
+license: Unknown
+long_description: 'Audiobookshelf is a self-hosted media server designed for managing
+  and streaming audiobooks, podcasts, and e-books, offering a secure and flexible
+  solution for personal media libraries. Its lightweight architecture and intuitive
+  Web interface (available as a Progressive Web App, PWA) enable seamless access from
+  any browser, while beta Android and iOS apps support offline listening, catering
+  to privacy-focused media enthusiasts.
+
+
+  The app supports on-the-fly streaming of all audio formats and provides robust management
+  tools, including automatic metadata and cover art fetching from multiple sources,
+  bulk drag-and-drop uploads for books and podcasts, and chapter editing with lookup
+  via the Audnexus API. Users can search and subscribe to podcasts with auto-downloading
+  episodes or manage content via open RSS feeds. It supports multi-user access with
+  custom permissions, ensuring individual playback progress syncs across devices.
+  Additionally, it offers audio tools (like merging files into m4b or embedding metadata)
+  and experimental e-book support (epub, pdf, cbr, cbz), with the ability to send
+  e-books to devices like Kindle.
+
+
+  It automatically detects library updates, eliminating manual rescans, and includes
+  daily automated backups to safeguard metadata. Chromecast support (on Web and Android
+  apps) enhances streaming capabilities, while an active community provides support
+  documentation for continuous improvements. Whether for personal collections or family
+  sharing, the app''s intuitive interface and versatile features deliver a modern
+  media management platform, meeting diverse needs.
+
+
+  **Key Features:**
+
+  - Multi-user support w/ custom permissions
+
+  - Keeps progress per user and syncs across devices
+
+  - Lookup and apply metadata and cover art from several providers
+
+  - Audiobook chapter editor w/ chapter lookup
+
+  - Audiobook tools: Embed metadata in audio files & merge multiple audio files to
+  a single m4b
+
+  - Search and add podcasts to download episodes w/ auto-download
+
+  - Open RSS feeds for audiobooks and podcast episodes
+
+  - Backups with automated backup scheduling
+
+  - Basic ebook support and ereader (epub, pdf, cbr, cbz) + send to device (i.e. Kindle)
+
+
+  **Learn More:**
+
+  - [Audiobookshelf Official Website](https://audiobookshelf.org)
+
+  - [Audiobookshelf GitHub Repository](https://github.com/advplyr/audiobookshelf)
+
+  '
+maintainer: advplyr <auto-converted@casaos.io>
+name: audiobookshelf
+package_name: casaos-audiobookshelf-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Audiobookshelf/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Audiobookshelf/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Audiobookshelf/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/autobrr/config.yml
+++ b/sources/casaos-official/apps/autobrr/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/autobrr/docker-compose.yml
+++ b/sources/casaos-official/apps/autobrr/docker-compose.yml
@@ -1,0 +1,14 @@
+name: autobrr
+services:
+  autobrr:
+    environment:
+      TZ: ${TZ}
+    image: ghcr.io/autobrr/autobrr:v1.69.0
+    ports:
+    - protocol: tcp
+      published: 7474
+      target: 7474
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/autobrr/metadata.yaml
+++ b/sources/casaos-official/apps/autobrr/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: video
+description: Modern, easy to use download automation for torrents and usenet.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Autobrr/icon.png
+license: Unknown
+long_description: Autobrr is the modern download automation tool for torrents and
+  usenet. With inspiration and ideas from tools like trackarr, autodl-irssi and flexget
+  we built one tool that can do it all, and then some.
+maintainer: Autobrr Team <auto-converted@casaos.io>
+name: autobrr
+package_name: casaos-autobrr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Autobrr/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/bazarr/config.yml
+++ b/sources/casaos-official/apps/bazarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/bazarr/docker-compose.yml
+++ b/sources/casaos-official/apps/bazarr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: bazarr
+services:
+  bazarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/bazarr:1.5.3
+    ports:
+    - protocol: tcp
+      published: 6767
+      target: 6767
+    volumes:
+    - source: /Media/Movies
+      target: /movies
+      type: bind
+    - source: /Media/TV Shows
+      target: /tv
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/bazarr/metadata.yaml
+++ b/sources/casaos-official/apps/bazarr/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: video
+description: Letter generators for Sonarr and Radarr
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/icon.png
+license: Unknown
+long_description: Bazarr is a companion application to Sonarr and Radarr. It can manage
+  and download subtitles based on your requirements. You define your preferences by
+  TV show or movie and Bazarr takes care of everything for you.
+maintainer: Sabnzbd Team <auto-converted@casaos.io>
+name: bazarr
+package_name: casaos-bazarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bazarr/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/beaverhabittracker/config.yml
+++ b/sources/casaos-official/apps/beaverhabittracker/config.yml
@@ -1,0 +1,30 @@
+groups:
+- description: null
+  fields:
+  - default: USER_DISK
+    description: Sets the storage type for habits
+    id: HABITS_STORAGE
+    label: HABITS_STORAGE
+    required: false
+    type: string
+  - default: your@email.com
+    description: Sets the trusted local email
+    id: TRUSTED_LOCAL_EMAIL
+    label: TRUSTED_LOCAL_EMAIL
+    required: false
+    type: string
+  - default: '5'
+    description: Customize the displayed dates for the index page
+    id: INDEX_HABIT_DATE_COLUMNS
+    label: INDEX_HABIT_DATE_COLUMNS
+    required: false
+    type: string
+  - default: 'True'
+    description: Enables iOS standalone mode
+    id: ENABLE_IOS_STANDALONE
+    label: ENABLE_IOS_STANDALONE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/beaverhabittracker/docker-compose.yml
+++ b/sources/casaos-official/apps/beaverhabittracker/docker-compose.yml
@@ -1,0 +1,17 @@
+name: beaverhabittracker
+services:
+  beaverhabittracker:
+    environment:
+      ENABLE_IOS_STANDALONE: ${ENABLE_IOS_STANDALONE}
+      HABITS_STORAGE: ${HABITS_STORAGE}
+      INDEX_HABIT_DATE_COLUMNS: ${INDEX_HABIT_DATE_COLUMNS}
+      TRUSTED_LOCAL_EMAIL: ${TRUSTED_LOCAL_EMAIL}
+    image: daya0576/beaverhabits:0.7.3
+    ports:
+    - protocol: tcp
+      published: 15580
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/
+      target: /app/.user
+      type: bind

--- a/sources/casaos-official/apps/beaverhabittracker/metadata.yaml
+++ b/sources/casaos-official/apps/beaverhabittracker/metadata.yaml
@@ -1,0 +1,57 @@
+architecture: all
+debian_section: utils
+description: A self-hosted, goal-free habit tracking tool.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/BeaverHabitTracker/icon.png
+license: Unknown
+long_description: 'Beaver Habit Tracker is a self-hosted habit tracking tool designed
+  for users who want to effortlessly monitor daily behaviors without the stress of
+  goal-setting. Its intuitive Web interface offers a pressure-free tracking experience,
+  ideal for those focused on behavior observation and personal growth.
+
+
+  The tool''s core features include goal-free habit tracking and a minimalist interface.
+  It allows users to log multiple habits easily, without focusing on streaks or targets,
+  and provides simple visualizations to understand behavior patterns. Users can add
+  daily notes to record specific activities or reflections, with a smooth, low-effort
+  interface.
+
+
+  It uses a self-hosted approach, ensuring data privacy and full control, with a lightweight,
+  efficient design requiring minimal server resources. Users can manually reorder
+  habits for an optimized experience. The tool''s stress-free observation and intuitive
+  operation help users gradually improve habits, delivering a modern habit management
+  solution.
+
+
+  **Key Features:**
+
+  - Goal-free habit tracking focused on awareness, not achievement
+
+  - Clean, minimalist interface for effortless daily logging
+
+  - Lightweight and efficient, requiring minimal server resources
+
+  - Simple visualizations to understand behavior patterns
+
+  - Daily notes for recording activities or reflections
+
+
+  **Learn More:**
+
+  - [Beaver Habit Tracker Official Website](https://beaverhabits.com/)
+
+  - [Beaver Habit Tracker GitHub](https://github.com/daya0576/beaverhabits)
+
+  '
+maintainer: daya0576 <auto-converted@casaos.io>
+name: beaverhabittracker
+package_name: casaos-beaverhabittracker-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/BeaverHabitTracker/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/BeaverHabitTracker/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/BeaverHabitTracker/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/bili-sync/config.yml
+++ b/sources/casaos-official/apps/bili-sync/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/bili-sync/docker-compose.yml
+++ b/sources/casaos-official/apps/bili-sync/docker-compose.yml
@@ -1,0 +1,15 @@
+name: bili-sync
+services:
+  bili-sync-rs:
+    image: amtoaer/bili-sync-rs:v2.5.0
+    ports:
+    - protocol: tcp
+      published: 12345
+      target: 12345
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}
+      target: /app/.config/bili-sync
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /DATA
+      type: bind

--- a/sources/casaos-official/apps/bili-sync/metadata.yaml
+++ b/sources/casaos-official/apps/bili-sync/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: video
+description: bili-sync is a Bilibili synchronization tool written specifically for
+  NAS...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bili-Sync/logo.png
+license: Unknown
+long_description: 'bili-sync is a Bilibili synchronization tool written specifically
+  for NAS users, powered by Rust & Tokio.
+
+
+  bili-sync is a Bilibili synchronization tool written specifically for NAS users,
+  powered by Rust & Tokio.'
+maintainer: amtoaer <auto-converted@casaos.io>
+name: bili-sync
+package_name: casaos-bili-sync-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Bili-Sync/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/calibre-web/config.yml
+++ b/sources/casaos-official/apps/calibre-web/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: ghcr.io/linuxserver/mods:universal-calibre
+    description: ''
+    id: DOCKER_MODS
+    label: DOCKER_MODS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/calibre-web/docker-compose.yml
+++ b/sources/casaos-official/apps/calibre-web/docker-compose.yml
@@ -1,0 +1,20 @@
+name: calibre-web
+services:
+  calibre-web:
+    environment:
+      DOCKER_MODS: ${DOCKER_MODS}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/calibre-web:0.6.24
+    ports:
+    - protocol: tcp
+      published: 8083
+      target: 8083
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/Books
+      target: /books
+      type: bind

--- a/sources/casaos-official/apps/calibre-web/metadata.yaml
+++ b/sources/casaos-official/apps/calibre-web/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: video
+description: Web app for browsing, reading and downloading eBooks stored in a Calibre...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/icon.png
+license: Unknown
+long_description: 'Web app for browsing, reading and downloading eBooks stored in
+  a Calibre database
+
+
+  Calibre-web is a web app providing a clean interface for browsing, reading and downloading
+  eBooks using an existing Calibre database. It is also possible to integrate google
+  drive and edit metadata and your calibre library through the app itself.'
+maintainer: linuxserver <auto-converted@casaos.io>
+name: calibre-web
+package_name: casaos-calibre-web-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Calibre-web/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/chatbot-ui/config.yml
+++ b/sources/casaos-official/apps/chatbot-ui/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/chatbot-ui/docker-compose.yml
+++ b/sources/casaos-official/apps/chatbot-ui/docker-compose.yml
@@ -1,0 +1,12 @@
+name: chatbot-ui
+services:
+  chatbot-ui:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: ghcr.io/mckaywrigley/chatbot-ui:main
+    ports:
+    - protocol: tcp
+      published: 3080
+      target: 3000

--- a/sources/casaos-official/apps/chatbot-ui/metadata.yaml
+++ b/sources/casaos-official/apps/chatbot-ui/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: comm
+description: Open source chat UI for AI models
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ChatbotUI/icon.jpg
+license: Unknown
+long_description: Chatbot UI is an open source chat UI for AI models.
+maintainer: Mckay Wrigley <auto-converted@casaos.io>
+name: chatbot-ui
+package_name: casaos-chatbot-ui-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ChatbotUI/screenshot-1.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/chatgpt-next-web/config.yml
+++ b/sources/casaos-official/apps/chatgpt-next-web/config.yml
@@ -1,0 +1,54 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: timezone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: ''
+    description: Access password, separated by comma.
+    id: CODE
+    label: CODE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: ''
+    description: http proxy
+    id: PROXY_URL
+    label: PROXY_URL
+    required: false
+    type: string
+  - default: https://api.openai.com
+    description: Override OpenAI API request base URL.
+    id: BASE_URL
+    label: BASE_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/chatgpt-next-web/docker-compose.yml
+++ b/sources/casaos-official/apps/chatgpt-next-web/docker-compose.yml
@@ -1,0 +1,15 @@
+name: chatgpt-next-web
+services:
+  chatgpt-next-web:
+    environment:
+      BASE_URL: ${BASE_URL}
+      CODE: ${CODE}
+      PGID: ${PGID}
+      PROXY_URL: ${PROXY_URL}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: yidadaa/chatgpt-next-web:v2.16.0
+    ports:
+    - protocol: tcp
+      published: 3000
+      target: 3000

--- a/sources/casaos-official/apps/chatgpt-next-web/metadata.yaml
+++ b/sources/casaos-official/apps/chatgpt-next-web/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: utils
+description: A well-designed cross-platform ChatGPT UI.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ChatGPT-Next-Web/icon.png
+license: Unknown
+long_description: An intelligent chat application based on ChatGPT, supports fast
+  deployment, Markdown, beautiful UI, fluid response, privacy and security, and allows
+  customization of preset roles for quick creation, sharing, and debugging of personalized
+  conversations.
+maintainer: Yidadaa <auto-converted@casaos.io>
+name: chatgpt-next-web
+package_name: casaos-chatgpt-next-web-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ChatGPT-Next-Web/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ChatGPT-Next-Web/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/cloudbeaver/config.yml
+++ b/sources/casaos-official/apps/cloudbeaver/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/cloudbeaver/docker-compose.yml
+++ b/sources/casaos-official/apps/cloudbeaver/docker-compose.yml
@@ -1,0 +1,12 @@
+name: cloudbeaver
+services:
+  cloudbeaver:
+    image: dbeaver/cloudbeaver:25.0.0
+    ports:
+    - protocol: tcp
+      published: 8978
+      target: 8978
+    volumes:
+    - source: /AppData/$AppID/workspace
+      target: /opt/cloudbeaver/workspace
+      type: bind

--- a/sources/casaos-official/apps/cloudbeaver/metadata.yaml
+++ b/sources/casaos-official/apps/cloudbeaver/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: devel
+description: Cloud Database Manager.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/CloudBeaver/icon.png
+license: Unknown
+long_description: CloudBeaver is a web-based database GUI tool which provides rich
+  web interface. You can use it to manage PostgreSQL, MySQL, MariaDB, SQL Server,
+  Oracle, DB2, Firebird, H2, Trino.
+maintainer: dbeaver <auto-converted@casaos.io>
+name: cloudbeaver
+package_name: casaos-cloudbeaver-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/CloudBeaver/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/CloudBeaver/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/CloudBeaver/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/cloudflared/config.yml
+++ b/sources/casaos-official/apps/cloudflared/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/cloudflared/docker-compose.yml
+++ b/sources/casaos-official/apps/cloudflared/docker-compose.yml
@@ -1,0 +1,12 @@
+name: cloudflared
+services:
+  cloudflared:
+    image: wisdomsky/cloudflared-web:2025.2.1
+    ports:
+    - protocol: tcp
+      published: 14333
+      target: 14333
+    volumes:
+    - source: /AppData/casaos-cloudflared/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/cloudflared/metadata.yaml
+++ b/sources/casaos-official/apps/cloudflared/metadata.yaml
@@ -1,0 +1,40 @@
+architecture: all
+debian_section: devel
+description: A tunneling daemon by Cloudflare that safely exposes your web servers
+  into...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Cloudflared/icon.png
+license: Unknown
+long_description: "A tunneling daemon by Cloudflare that safely exposes your web servers\
+  \ into the internet.\n\nCloudflare Tunnel offers an easy way to expose web servers\
+  \ securely to the internet, without opening up firewall ports and configuring ACLs.\
+  \ Cloudflare Tunnel also ensures requests route through Cloudflare before reaching\
+  \ the web server, so you can be sure attack traffic is stopped with Cloudflare’s\
+  \ WAF and Unmetered DDoS mitigation, and authenticated with Access if you’ve enabled\
+  \ those features for your account.\n\nThe software provides a seamless way to securely\
+  \ expose web servers to the internet without configuring firewall ports or access\
+  \ control lists (ACLs). All requests are routed through Cloudflare before reaching\
+  \ your web server, leveraging Cloudflare’s Web Application Firewall (WAF) and unmetered\
+  \ DDoS mitigation to block attack traffic, with optional authentication via Cloudflare\
+  \ Access if enabled. With its intuitive Web interface and efficient tunnel management,\
+  \ this tool is the perfect solution for securely deploying web services.\n\n**Discover\
+  \ How to Connect ZimaOS to Cloudflare Tunnel**\nIntegrating ZimaOS with Cloudflare\
+  \ Tunnel allows you to securely expose local services to the internet without opening\
+  \ firewall ports, enabling seamless remote access. Below are two practical resources\
+  \ to guide you through the setup process:\n1. [**Cloudflare Official Tutorial**](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/):\
+  \ \n  This tutorial provides detailed steps for creating and managing a Cloudflare\
+  \ Tunnel.\n2. [**Phiptech Practical Guide**](https://phiptech.com/how-to-setup-cloudflare-tunnel-and-expose-your-local-service-or-application/):\
+  \ \n  This guide offers a concise, step-by-step walkthrough for setting up Cloudflare\
+  \ Tunnel on local devices like ZimaOS, with practical examples to help users easily\
+  \ expose services to the public internet.\n"
+maintainer: Cloudflare Inc. <auto-converted@casaos.io>
+name: cloudflared
+package_name: casaos-cloudflared-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Cloudflared/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Cloudflared/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Cloudflared/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/convertx/config.yml
+++ b/sources/casaos-official/apps/convertx/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: aLongAndSecretStringUsedToSignTheJSONWebToken1234
+    description: JWT Secret Key
+    id: JWT_SECRET
+    label: JWT_SECRET
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: 'true'
+    description: Allow HTTP Connections
+    id: HTTP_ALLOWED
+    label: HTTP_ALLOWED
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/convertx/docker-compose.yml
+++ b/sources/casaos-official/apps/convertx/docker-compose.yml
@@ -1,0 +1,15 @@
+name: convertx
+services:
+  convertx:
+    environment:
+      HTTP_ALLOWED: ${HTTP_ALLOWED}
+      JWT_SECRET: ${JWT_SECRET}
+    image: c4illin/convertx:v0.14.1
+    ports:
+    - protocol: tcp
+      published: 3333
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /app/data
+      type: bind

--- a/sources/casaos-official/apps/convertx/metadata.yaml
+++ b/sources/casaos-official/apps/convertx/metadata.yaml
@@ -1,0 +1,55 @@
+architecture: all
+debian_section: utils
+description: A versatile file conversion tool that supports multiple formats.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ConvertX/icon.png
+license: Unknown
+long_description: 'ConvertX is a self-hosted file conversion service that allows users
+  to convert files between different formats through an intuitive web interface. It
+  supports a wide range of file types including documents, images, videos, and audio
+  files, making it a comprehensive solution for all your file conversion needs.
+
+
+  The service is designed with simplicity and ease of use in mind. Users can simply
+  upload their files, select the desired output format, and let ConvertX handle the
+  conversion process. The web interface provides a clean and user-friendly experience,
+  with drag-and-drop support and batch conversion capabilities.
+
+
+  ConvertX runs entirely on your own infrastructure, ensuring that your files remain
+  private and secure. There''s no need to upload sensitive documents to third-party
+  services, giving you full control over your data. The service is containerized for
+  easy deployment and can be integrated into existing home server setups.
+
+
+  **Key Features:**
+
+  - Support for multiple file formats (documents, images, videos, audio)
+
+  - Intuitive web interface with drag-and-drop support
+
+  - Batch conversion capabilities
+
+  - Self-hosted for privacy and security
+
+  - Containerized for easy deployment
+
+  - No file size limitations
+
+
+  **Learn More:**
+
+  - [ConvertX GitHub Repository](https://github.com/c4illin/convertx)
+
+  '
+maintainer: c4illin <auto-converted@casaos.io>
+name: convertx
+package_name: casaos-convertx-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ConvertX/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ConvertX/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ConvertX/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/crafty/config.yml
+++ b/sources/casaos-official/apps/crafty/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: Etc/UTC
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/crafty/docker-compose.yml
+++ b/sources/casaos-official/apps/crafty/docker-compose.yml
@@ -1,0 +1,32 @@
+name: crafty
+services:
+  crafty:
+    environment:
+      TZ: ${TZ}
+    image: registry.gitlab.com/crafty-controller/crafty-4:4.4.11
+    ports:
+    - protocol: tcp
+      published: 8111
+      target: 8443
+    - protocol: tcp
+      published: 8112
+      target: 8123
+    - protocol: udp
+      published: 19132
+      target: 19132
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/backups
+      target: /crafty/backups
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/logs
+      target: /crafty/logs
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/servers
+      target: /crafty/servers
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /crafty/app/config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/import
+      target: /crafty/import
+      type: bind

--- a/sources/casaos-official/apps/crafty/metadata.yaml
+++ b/sources/casaos-official/apps/crafty/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: games
+description: Take control of your Minecraft servers.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/icon.png
+license: Unknown
+long_description: Crafty is an open source Minecraft control panel built using Tornado
+  and AdminLTE, featuring server scheduling, a interactive console and the ability
+  to run almost any type of Minecraft server
+maintainer: Crafty Team <auto-converted@casaos.io>
+name: crafty
+package_name: casaos-crafty-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-6.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Crafty/screenshot-7.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/databag/config.yml
+++ b/sources/casaos-official/apps/databag/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/databag/docker-compose.yml
+++ b/sources/casaos-official/apps/databag/docker-compose.yml
@@ -1,0 +1,12 @@
+name: databag
+services:
+  databag:
+    image: balzack/databag:0.1.17
+    ports:
+    - protocol: tcp
+      published: 7000
+      target: 7000
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/data
+      target: /var/lib/databag
+      type: bind

--- a/sources/casaos-official/apps/databag/metadata.yaml
+++ b/sources/casaos-official/apps/databag/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: comm
+description: Messenger for the Decentralized Web
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Databag/icon.png
+license: Unknown
+long_description: Databag is a federated chat app for self-hosting that focuses on
+  user privacy and security; the service includes clients for iOS, Android, and browser.
+maintainer: balzack <auto-converted@casaos.io>
+name: databag
+package_name: casaos-databag-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Databag/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Databag/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ddns-go/config.yml
+++ b/sources/casaos-official/apps/ddns-go/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/ddns-go/docker-compose.yml
+++ b/sources/casaos-official/apps/ddns-go/docker-compose.yml
@@ -1,0 +1,12 @@
+name: ddns-go
+services:
+  ddns-go:
+    image: jeessy/ddns-go:v6.8.1
+    ports:
+    - protocol: tcp
+      published: 9876
+      target: 9876
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /root
+      type: bind

--- a/sources/casaos-official/apps/ddns-go/metadata.yaml
+++ b/sources/casaos-official/apps/ddns-go/metadata.yaml
@@ -1,0 +1,25 @@
+architecture: all
+debian_section: net
+description: Simple and easy to use DDNS
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ddns-go/icon.png
+license: Unknown
+long_description: 'A simple and easy-to-use DDNS tool. Automatically updates domain
+  name resolution to your public IP (supports Alibaba Cloud, Tencent Cloud, Dnspod,
+  Cloudflare, Callback, Huawei Cloud, Baidu Cloud, Porkbun, GoDaddy, and Google Domain).
+
+
+  Deploy DDNS-go on Zima, and you can bind the public IP of your Zima device to your
+  domain name. This way, you can access your Zima device via the domain name while
+  you are away.
+
+  '
+maintainer: jeessy2 <auto-converted@casaos.io>
+name: ddns-go
+package_name: casaos-ddns-go-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ddns-go/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ddns-updater/config.yml
+++ b/sources/casaos-official/apps/ddns-updater/config.yml
@@ -1,0 +1,116 @@
+groups:
+- description: null
+  fields:
+  - default: /updater/data
+    description: ''
+    id: BACKUP_DIRECTORY
+    label: BACKUP_DIRECTORY
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+- description: null
+  fields:
+  - default: '0'
+    description: ''
+    id: BACKUP_PERIOD
+    label: BACKUP_PERIOD
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: CONFIG
+    label: CONFIG
+    required: false
+    type: string
+  - default: 10s
+    description: ''
+    id: HTTP_TIMEOUT
+    label: HTTP_TIMEOUT
+    required: false
+    type: integer
+  - default: :8000
+    description: ''
+    id: LISTENING_ADDRESS
+    label: LISTENING_ADDRESS
+    required: false
+    type: string
+  - default: hidden
+    description: ''
+    id: LOG_CALLER
+    label: LOG_CALLER
+    required: false
+    type: string
+  - default: info
+    description: ''
+    id: LOG_LEVEL
+    label: LOG_LEVEL
+    required: false
+    type: string
+  - default: 5m
+    description: ''
+    id: PERIOD
+    label: PERIOD
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: PUBLICIP_DNS_PROVIDERS
+    label: PUBLICIP_DNS_PROVIDERS
+    required: false
+    type: string
+  - default: 3s
+    description: ''
+    id: PUBLICIP_DNS_TIMEOUT
+    label: PUBLICIP_DNS_TIMEOUT
+    required: false
+    type: integer
+  - default: all
+    description: ''
+    id: PUBLICIP_FETCHERS
+    label: PUBLICIP_FETCHERS
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: PUBLICIP_HTTP_PROVIDERS
+    label: PUBLICIP_HTTP_PROVIDERS
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: PUBLICIPV4_HTTP_PROVIDERS
+    label: PUBLICIPV4_HTTP_PROVIDERS
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: PUBLICIPV6_HTTP_PROVIDERS
+    label: PUBLICIPV6_HTTP_PROVIDERS
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: SHOUTRRR_ADDRESSES
+    label: SHOUTRRR_ADDRESSES
+    required: false
+    type: string
+  - default: 5m
+    description: ''
+    id: UPDATE_COOLDOWN_PERIOD
+    label: UPDATE_COOLDOWN_PERIOD
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: /
+    description: ''
+    id: ROOT_URL
+    label: ROOT_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/ddns-updater/docker-compose.yml
+++ b/sources/casaos-official/apps/ddns-updater/docker-compose.yml
@@ -1,0 +1,32 @@
+name: ddns-updater
+services:
+  ddns-updater:
+    command:
+    - touch /data/config.json
+    environment:
+      BACKUP_DIRECTORY: ${BACKUP_DIRECTORY}
+      BACKUP_PERIOD: ${BACKUP_PERIOD}
+      CONFIG: ${CONFIG}
+      HTTP_TIMEOUT: ${HTTP_TIMEOUT}
+      LISTENING_ADDRESS: ${LISTENING_ADDRESS}
+      LOG_CALLER: ${LOG_CALLER}
+      LOG_LEVEL: ${LOG_LEVEL}
+      PERIOD: ${PERIOD}
+      PUBLICIPV4_HTTP_PROVIDERS: ${PUBLICIPV4_HTTP_PROVIDERS}
+      PUBLICIPV6_HTTP_PROVIDERS: ${PUBLICIPV6_HTTP_PROVIDERS}
+      PUBLICIP_DNS_PROVIDERS: ${PUBLICIP_DNS_PROVIDERS}
+      PUBLICIP_DNS_TIMEOUT: ${PUBLICIP_DNS_TIMEOUT}
+      PUBLICIP_FETCHERS: ${PUBLICIP_FETCHERS}
+      PUBLICIP_HTTP_PROVIDERS: ${PUBLICIP_HTTP_PROVIDERS}
+      ROOT_URL: ${ROOT_URL}
+      SHOUTRRR_ADDRESSES: ${SHOUTRRR_ADDRESSES}
+      UPDATE_COOLDOWN_PERIOD: ${UPDATE_COOLDOWN_PERIOD}
+    image: qmcgaw/ddns-updater:v2.9.0
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /updater/data
+      type: bind

--- a/sources/casaos-official/apps/ddns-updater/metadata.yaml
+++ b/sources/casaos-official/apps/ddns-updater/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: net
+description: Simple and easy to use DDNS
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/DDNS-Updater/icon.png
+license: Unknown
+long_description: Program to keep DNS A and/or AAAA records updated for multiple DNS
+  providers
+maintainer: qmcgaw <auto-converted@casaos.io>
+name: ddns-updater
+package_name: casaos-ddns-updater-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/deluge/config.yml
+++ b/sources/casaos-official/apps/deluge/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: error
+    description: Deluge Log Level
+    id: DELUGE_LOGLEVEL
+    label: DELUGE_LOGLEVEL
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Deluge as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Deluge as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/deluge/docker-compose.yml
+++ b/sources/casaos-official/apps/deluge/docker-compose.yml
@@ -1,0 +1,26 @@
+name: deluge
+services:
+  deluge:
+    environment:
+      DELUGE_LOGLEVEL: ${DELUGE_LOGLEVEL}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/deluge:2.1.1
+    ports:
+    - protocol: tcp
+      published: 8112
+      target: 8112
+    - protocol: tcp
+      published: 6881
+      target: 6881
+    - protocol: udp
+      published: 6881
+      target: 6881
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /DATA
+      type: bind

--- a/sources/casaos-official/apps/deluge/metadata.yaml
+++ b/sources/casaos-official/apps/deluge/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: misc
+description: A lightweight and free BitTorrent client.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Deluge/icon.png
+license: Unknown
+long_description: Deluge contains the common features to BitTorrent clients such as
+  Protocol Encryption, DHT, Local Peer Discovery (LSD), Peer Exchange (PEX), UPnP,
+  NAT-PMP, Proxy support, Web seeds, global and per-torrent speed limits. As Deluge
+  heavily utilises the ​libtorrent library it has a comprehensive list of the ​features
+  provided.
+maintainer: Deluge Team <auto-converted@casaos.io>
+name: deluge
+package_name: casaos-deluge-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Deluge/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Deluge/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Deluge/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Deluge/screenshot-4.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/dify/config.yml
+++ b/sources/casaos-official/apps/dify/config.yml
@@ -1,0 +1,562 @@
+groups:
+- description: null
+  fields:
+  - default: api
+    description: ''
+    id: MODE
+    label: MODE
+    required: false
+    type: string
+  - default: INFO
+    description: ''
+    id: LOG_LEVEL
+    label: LOG_LEVEL
+    required: false
+    type: string
+  - default: '300'
+    description: ''
+    id: FILES_ACCESS_TIMEOUT
+    label: FILES_ACCESS_TIMEOUT
+    required: false
+    type: integer
+  - default: 'true'
+    description: ''
+    id: MIGRATION_ENABLED
+    label: MIGRATION_ENABLED
+    required: false
+    type: boolean
+  - default: dify
+    description: ''
+    id: DB_DATABASE
+    label: DB_DATABASE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: REDIS_DB
+    label: REDIS_DB
+    required: false
+    type: string
+  - default: '*'
+    description: ''
+    id: WEB_API_CORS_ALLOW_ORIGINS
+    label: WEB_API_CORS_ALLOW_ORIGINS
+    required: false
+    type: string
+  - default: '*'
+    description: ''
+    id: CONSOLE_CORS_ALLOW_ORIGINS
+    label: CONSOLE_CORS_ALLOW_ORIGINS
+    required: false
+    type: string
+  - default: local
+    description: ''
+    id: STORAGE_TYPE
+    label: STORAGE_TYPE
+    required: false
+    type: string
+  - default: weaviate
+    description: ''
+    id: VECTOR_STORE
+    label: VECTOR_STORE
+    required: false
+    type: string
+  - default: http://weaviate:8080
+    description: ''
+    id: WEAVIATE_ENDPOINT
+    label: WEAVIATE_ENDPOINT
+    required: false
+    type: string
+  - default: http://sandbox:8194
+    description: ''
+    id: CODE_EXECUTION_ENDPOINT
+    label: CODE_EXECUTION_ENDPOINT
+    required: false
+    type: string
+  - default: '9223372036854775807'
+    description: ''
+    id: CODE_MAX_NUMBER
+    label: CODE_MAX_NUMBER
+    required: false
+    type: string
+  - default: '-9223372036854775808'
+    description: ''
+    id: CODE_MIN_NUMBER
+    label: CODE_MIN_NUMBER
+    required: false
+    type: string
+  - default: '80000'
+    description: ''
+    id: CODE_MAX_STRING_LENGTH
+    label: CODE_MAX_STRING_LENGTH
+    required: false
+    type: string
+  - default: '80000'
+    description: ''
+    id: TEMPLATE_TRANSFORM_MAX_LENGTH
+    label: TEMPLATE_TRANSFORM_MAX_LENGTH
+    required: false
+    type: string
+  - default: '30'
+    description: ''
+    id: CODE_MAX_STRING_ARRAY_LENGTH
+    label: CODE_MAX_STRING_ARRAY_LENGTH
+    required: false
+    type: string
+  - default: '30'
+    description: ''
+    id: CODE_MAX_OBJECT_ARRAY_LENGTH
+    label: CODE_MAX_OBJECT_ARRAY_LENGTH
+    required: false
+    type: string
+  - default: '1000'
+    description: ''
+    id: CODE_MAX_NUMBER_ARRAY_LENGTH
+    label: CODE_MAX_NUMBER_ARRAY_LENGTH
+    required: false
+    type: string
+  - default: '1000'
+    description: ''
+    id: INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH
+    label: INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH
+    required: false
+    type: string
+  - default: worker
+    description: ''
+    id: MODE
+    label: MODE
+    required: false
+    type: string
+  - default: INFO
+    description: ''
+    id: LOG_LEVEL
+    label: LOG_LEVEL
+    required: false
+    type: string
+  - default: dify
+    description: ''
+    id: DB_DATABASE
+    label: DB_DATABASE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: REDIS_DB
+    label: REDIS_DB
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: REDIS_USE_SSL
+    label: REDIS_USE_SSL
+    required: false
+    type: string
+  - default: local
+    description: ''
+    id: STORAGE_TYPE
+    label: STORAGE_TYPE
+    required: false
+    type: string
+  - default: weaviate
+    description: ''
+    id: VECTOR_STORE
+    label: VECTOR_STORE
+    required: false
+    type: string
+  - default: http://weaviate:8080
+    description: ''
+    id: WEAVIATE_ENDPOINT
+    label: WEAVIATE_ENDPOINT
+    required: false
+    type: string
+  - default: dify
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: /var/lib/postgresql/data/pgdata
+    description: ''
+    id: PGDATA
+    label: PGDATA
+    required: false
+    type: string
+  - default: difyai123456
+    description: ''
+    id: REDISCLI_AUTH
+    label: REDISCLI_AUTH
+    required: false
+    type: string
+  - default: '25'
+    description: ''
+    id: QUERY_DEFAULTS_LIMIT
+    label: QUERY_DEFAULTS_LIMIT
+    required: false
+    type: integer
+  - default: 'false'
+    description: ''
+    id: AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED
+    label: AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED
+    required: false
+    type: boolean
+  - default: none
+    description: ''
+    id: DEFAULT_VECTORIZER_MODULE
+    label: DEFAULT_VECTORIZER_MODULE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: AUTHENTICATION_APIKEY_ENABLED
+    label: AUTHENTICATION_APIKEY_ENABLED
+    required: false
+    type: boolean
+  - default: WVF5YThaHlkYwhGUSmCRgsX3tD5ngdN8pkih
+    description: ''
+    id: AUTHENTICATION_APIKEY_ALLOWED_KEYS
+    label: AUTHENTICATION_APIKEY_ALLOWED_KEYS
+    required: false
+    type: string
+  - default: hello@dify.ai
+    description: ''
+    id: AUTHENTICATION_APIKEY_USERS
+    label: AUTHENTICATION_APIKEY_USERS
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: AUTHORIZATION_ADMINLIST_ENABLED
+    label: AUTHORIZATION_ADMINLIST_ENABLED
+    required: false
+    type: boolean
+  - default: hello@dify.ai
+    description: ''
+    id: AUTHORIZATION_ADMINLIST_USERS
+    label: AUTHORIZATION_ADMINLIST_USERS
+    required: false
+    type: string
+  - default: release
+    description: ''
+    id: GIN_MODE
+    label: GIN_MODE
+    required: false
+    type: string
+  - default: '15'
+    description: ''
+    id: WORKER_TIMEOUT
+    label: WORKER_TIMEOUT
+    required: false
+    type: integer
+  - default: 'true'
+    description: ''
+    id: ENABLE_NETWORK
+    label: ENABLE_NETWORK
+    required: false
+    type: string
+  - default: http://ssrf_proxy:3128
+    description: ''
+    id: HTTP_PROXY
+    label: HTTP_PROXY
+    required: false
+    type: string
+  - default: http://ssrf_proxy:3128
+    description: ''
+    id: HTTPS_PROXY
+    label: HTTPS_PROXY
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: your-openai-api-key-here
+    description: ''
+    id: SECRET_KEY
+    label: SECRET_KEY
+    required: false
+    type: password
+  - default: ''
+    description: ''
+    id: INIT_PASSWORD
+    label: INIT_PASSWORD
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: DB_USERNAME
+    label: DB_USERNAME
+    required: false
+    type: string
+  - default: difyai123456
+    description: ''
+    id: DB_PASSWORD
+    label: DB_PASSWORD
+    required: false
+    type: password
+  - default: difyai123456
+    description: ''
+    id: REDIS_PASSWORD
+    label: REDIS_PASSWORD
+    required: false
+    type: password
+  - default: WVF5YThaHlkYwhGUSmCRgsX3tD5ngdN8pkih
+    description: ''
+    id: WEAVIATE_API_KEY
+    label: WEAVIATE_API_KEY
+    required: false
+    type: password
+  - default: dify-sandbox
+    description: ''
+    id: CODE_EXECUTION_API_KEY
+    label: CODE_EXECUTION_API_KEY
+    required: false
+    type: password
+  - default: your-openai-api-key-here
+    description: ''
+    id: SECRET_KEY
+    label: SECRET_KEY
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: DB_USERNAME
+    label: DB_USERNAME
+    required: false
+    type: string
+  - default: difyai123456
+    description: ''
+    id: DB_PASSWORD
+    label: DB_PASSWORD
+    required: false
+    type: password
+  - default: difyai123456
+    description: ''
+    id: REDIS_PASSWORD
+    label: REDIS_PASSWORD
+    required: false
+    type: password
+  - default: WVF5YThaHlkYwhGUSmCRgsX3tD5ngdN8pkih
+    description: ''
+    id: WEAVIATE_API_KEY
+    label: WEAVIATE_API_KEY
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: PGUSER
+    label: PGUSER
+    required: false
+    type: string
+  - default: difyai123456
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: dify-sandbox
+    description: ''
+    id: API_KEY
+    label: API_KEY
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: ''
+    description: ''
+    id: CONSOLE_WEB_URL
+    label: CONSOLE_WEB_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: CONSOLE_API_URL
+    label: CONSOLE_API_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: SERVICE_API_URL
+    label: SERVICE_API_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: APP_WEB_URL
+    label: APP_WEB_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: FILES_URL
+    label: FILES_URL
+    required: false
+    type: string
+  - default: db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis
+    description: ''
+    id: REDIS_HOST
+    label: REDIS_HOST
+    required: false
+    type: string
+  - default: '6379'
+    description: ''
+    id: REDIS_PORT
+    label: REDIS_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://:difyai123456@redis:6379/1
+    description: ''
+    id: CELERY_BROKER_URL
+    label: CELERY_BROKER_URL
+    required: false
+    type: string
+  - default: http://ssrf_proxy:3128
+    description: ''
+    id: SSRF_PROXY_HTTP_URL
+    label: SSRF_PROXY_HTTP_URL
+    required: false
+    type: string
+  - default: http://ssrf_proxy:3128
+    description: ''
+    id: SSRF_PROXY_HTTPS_URL
+    label: SSRF_PROXY_HTTPS_URL
+    required: false
+    type: string
+  - default: db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis
+    description: ''
+    id: REDIS_HOST
+    label: REDIS_HOST
+    required: false
+    type: string
+  - default: '6379'
+    description: ''
+    id: REDIS_PORT
+    label: REDIS_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://:difyai123456@redis:6379/1
+    description: ''
+    id: CELERY_BROKER_URL
+    label: CELERY_BROKER_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: CONSOLE_API_URL
+    label: CONSOLE_API_URL
+    required: false
+    type: string
+  - default: ''
+    description: ''
+    id: APP_API_URL
+    label: APP_API_URL
+    required: false
+    type: string
+  - default: node1
+    description: ''
+    id: CLUSTER_HOSTNAME
+    label: CLUSTER_HOSTNAME
+    required: false
+    type: string
+  - default: '8194'
+    description: ''
+    id: SANDBOX_PORT
+    label: SANDBOX_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: '3128'
+    description: ''
+    id: HTTP_PORT
+    label: HTTP_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: '8194'
+    description: ''
+    id: REVERSE_PROXY_PORT
+    label: REVERSE_PROXY_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: sandbox
+    description: ''
+    id: SANDBOX_HOST
+    label: SANDBOX_HOST
+    required: false
+    type: string
+  - default: '8194'
+    description: ''
+    id: SANDBOX_PORT
+    label: SANDBOX_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: storage
+    description: ''
+    id: STORAGE_LOCAL_PATH
+    label: STORAGE_LOCAL_PATH
+    required: false
+    type: path
+  - default: storage
+    description: ''
+    id: STORAGE_LOCAL_PATH
+    label: STORAGE_LOCAL_PATH
+    required: false
+    type: path
+  - default: /var/lib/weaviate
+    description: ''
+    id: PERSISTENCE_DATA_PATH
+    label: PERSISTENCE_DATA_PATH
+    required: false
+    type: path
+  - default: /var/spool/squid
+    description: ''
+    id: COREDUMP_DIR
+    label: COREDUMP_DIR
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/dify/docker-compose.yml
+++ b/sources/casaos-official/apps/dify/docker-compose.yml
@@ -1,0 +1,170 @@
+name: dify
+services:
+  api:
+    environment:
+      APP_WEB_URL: ${APP_WEB_URL}
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL}
+      CODE_EXECUTION_API_KEY: ${CODE_EXECUTION_API_KEY}
+      CODE_EXECUTION_ENDPOINT: ${CODE_EXECUTION_ENDPOINT}
+      CODE_MAX_NUMBER: ${CODE_MAX_NUMBER}
+      CODE_MAX_NUMBER_ARRAY_LENGTH: ${CODE_MAX_NUMBER_ARRAY_LENGTH}
+      CODE_MAX_OBJECT_ARRAY_LENGTH: ${CODE_MAX_OBJECT_ARRAY_LENGTH}
+      CODE_MAX_STRING_ARRAY_LENGTH: ${CODE_MAX_STRING_ARRAY_LENGTH}
+      CODE_MAX_STRING_LENGTH: ${CODE_MAX_STRING_LENGTH}
+      CODE_MIN_NUMBER: ${CODE_MIN_NUMBER}
+      CONSOLE_API_URL: ${CONSOLE_API_URL}
+      CONSOLE_CORS_ALLOW_ORIGINS: ${CONSOLE_CORS_ALLOW_ORIGINS}
+      CONSOLE_WEB_URL: ${CONSOLE_WEB_URL}
+      DB_DATABASE: ${DB_DATABASE}
+      DB_HOST: ${DB_HOST}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_PORT: ${DB_PORT}
+      DB_USERNAME: ${DB_USERNAME}
+      FILES_ACCESS_TIMEOUT: ${FILES_ACCESS_TIMEOUT}
+      FILES_URL: ${FILES_URL}
+      INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH: ${INDEXING_MAX_SEGMENTATION_TOKENS_LENGTH}
+      INIT_PASSWORD: ${INIT_PASSWORD}
+      LOG_LEVEL: ${LOG_LEVEL}
+      MIGRATION_ENABLED: ${MIGRATION_ENABLED}
+      MODE: ${MODE}
+      REDIS_DB: ${REDIS_DB}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      REDIS_PORT: ${REDIS_PORT}
+      SECRET_KEY: ${SECRET_KEY}
+      SERVICE_API_URL: ${SERVICE_API_URL}
+      SSRF_PROXY_HTTPS_URL: ${SSRF_PROXY_HTTPS_URL}
+      SSRF_PROXY_HTTP_URL: ${SSRF_PROXY_HTTP_URL}
+      STORAGE_LOCAL_PATH: ${STORAGE_LOCAL_PATH}
+      STORAGE_TYPE: ${STORAGE_TYPE}
+      TEMPLATE_TRANSFORM_MAX_LENGTH: ${TEMPLATE_TRANSFORM_MAX_LENGTH}
+      VECTOR_STORE: ${VECTOR_STORE}
+      WEAVIATE_API_KEY: ${WEAVIATE_API_KEY}
+      WEAVIATE_ENDPOINT: ${WEAVIATE_ENDPOINT}
+      WEB_API_CORS_ALLOW_ORIGINS: ${WEB_API_CORS_ALLOW_ORIGINS}
+    image: langgenius/dify-api:0.12.1
+    volumes:
+    - source: /AppData/$AppID/data/app/api/storage
+      target: /app/api/storage
+      type: bind
+  config:
+    image: ns2kracy/dify-config:latest
+    volumes:
+    - source: /AppData/$AppID/data/nginx
+      target: /configs/nginx
+      type: bind
+    - source: /AppData/$AppID/data/ssrf_proxy
+      target: /configs/ssrf_proxy
+      type: bind
+    - source: /AppData/$AppID/data/sandbox
+      target: /configs/sandbox
+      type: bind
+  db:
+    command:
+    - "postgres -c 'max_connections=100'\n         -c 'shared_buffers=128MB'\n   \
+      \      -c 'work_mem=4MB'\n         -c 'maintenance_work_mem=64MB'\n        \
+      \ -c 'effective_cache_size=4096MB'\n"
+    environment:
+      PGDATA: ${PGDATA}
+      PGUSER: ${PGUSER}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    image: postgres:15-alpine
+    volumes:
+    - source: /AppData/$AppID/data/db/data
+      target: /var/lib/postgresql/data
+      type: bind
+  nginx:
+    image: nginx:latest
+    ports:
+    - protocol: tcp
+      published: 3701
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/data/nginx
+      target: /etc/nginx
+      type: bind
+  redis:
+    command:
+    - redis-server --requirepass difyai123456
+    environment:
+      REDISCLI_AUTH: ${REDISCLI_AUTH}
+    image: redis:6-alpine
+    volumes:
+    - source: /AppData/$AppID/data/redis/data
+      target: /data
+      type: bind
+  sandbox:
+    environment:
+      API_KEY: ${API_KEY}
+      ENABLE_NETWORK: ${ENABLE_NETWORK}
+      GIN_MODE: ${GIN_MODE}
+      HTTPS_PROXY: ${HTTPS_PROXY}
+      HTTP_PROXY: ${HTTP_PROXY}
+      SANDBOX_PORT: ${SANDBOX_PORT}
+      WORKER_TIMEOUT: ${WORKER_TIMEOUT}
+    image: langgenius/dify-sandbox:0.2.10
+    volumes:
+    - source: /AppData/$AppID/data/sandbox/dependencies
+      target: /dependencies
+      type: bind
+  ssrf_proxy:
+    environment:
+      COREDUMP_DIR: ${COREDUMP_DIR}
+      HTTP_PORT: ${HTTP_PORT}
+      REVERSE_PROXY_PORT: ${REVERSE_PROXY_PORT}
+      SANDBOX_HOST: ${SANDBOX_HOST}
+      SANDBOX_PORT: ${SANDBOX_PORT}
+    image: ubuntu/squid:latest
+    volumes:
+    - source: /AppData/$AppID/data/ssrf_proxy
+      target: /etc/squid
+      type: bind
+  weaviate:
+    environment:
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: ${AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED}
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: ${AUTHENTICATION_APIKEY_ALLOWED_KEYS}
+      AUTHENTICATION_APIKEY_ENABLED: ${AUTHENTICATION_APIKEY_ENABLED}
+      AUTHENTICATION_APIKEY_USERS: ${AUTHENTICATION_APIKEY_USERS}
+      AUTHORIZATION_ADMINLIST_ENABLED: ${AUTHORIZATION_ADMINLIST_ENABLED}
+      AUTHORIZATION_ADMINLIST_USERS: ${AUTHORIZATION_ADMINLIST_USERS}
+      CLUSTER_HOSTNAME: ${CLUSTER_HOSTNAME}
+      DEFAULT_VECTORIZER_MODULE: ${DEFAULT_VECTORIZER_MODULE}
+      PERSISTENCE_DATA_PATH: ${PERSISTENCE_DATA_PATH}
+      QUERY_DEFAULTS_LIMIT: ${QUERY_DEFAULTS_LIMIT}
+    image: semitechnologies/weaviate:1.19.0
+    volumes:
+    - source: /AppData/$AppID/data/weaviate
+      target: /var/lib/weaviate
+      type: bind
+  web:
+    environment:
+      APP_API_URL: ${APP_API_URL}
+      CONSOLE_API_URL: ${CONSOLE_API_URL}
+    image: langgenius/dify-web:0.12.1
+  worker:
+    environment:
+      CELERY_BROKER_URL: ${CELERY_BROKER_URL}
+      DB_DATABASE: ${DB_DATABASE}
+      DB_HOST: ${DB_HOST}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_PORT: ${DB_PORT}
+      DB_USERNAME: ${DB_USERNAME}
+      LOG_LEVEL: ${LOG_LEVEL}
+      MODE: ${MODE}
+      REDIS_DB: ${REDIS_DB}
+      REDIS_HOST: ${REDIS_HOST}
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      REDIS_PORT: ${REDIS_PORT}
+      REDIS_USE_SSL: ${REDIS_USE_SSL}
+      SECRET_KEY: ${SECRET_KEY}
+      STORAGE_LOCAL_PATH: ${STORAGE_LOCAL_PATH}
+      STORAGE_TYPE: ${STORAGE_TYPE}
+      VECTOR_STORE: ${VECTOR_STORE}
+      WEAVIATE_API_KEY: ${WEAVIATE_API_KEY}
+      WEAVIATE_ENDPOINT: ${WEAVIATE_ENDPOINT}
+    image: langgenius/dify-api:0.12.1
+    volumes:
+    - source: /AppData/$AppID/data/app/api/storage
+      target: /app/api/storage
+      type: bind

--- a/sources/casaos-official/apps/dify/metadata.yaml
+++ b/sources/casaos-official/apps/dify/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: comm
+description: LLM App Development Platform
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Dify/icon.png
+license: Unknown
+long_description: Dify is an open-source large language model (LLM) application development
+  platform. It combines the concepts of Backend-as-a-Service and LLMOps to enable
+  developers to quickly build production-grade generative AI applications. Even non-technical
+  personnel can participate in the definition and data operations of AI applications.
+maintainer: LangGenius <auto-converted@casaos.io>
+name: dify
+package_name: casaos-dify-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Dify/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Dify/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Dify/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Dify/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/docmost/config.yml
+++ b/sources/casaos-official/apps/docmost/config.yml
@@ -1,0 +1,56 @@
+groups:
+- description: null
+  fields:
+  - default: http://localhost:3000
+    description: The base URL of your application
+    id: APP_URL
+    label: APP_URL
+    required: false
+    type: string
+  - default: postgresql://docmost:jcui51lw747yuuk4zrpm@docmost-db:5432/docmost?schema=public
+    description: Database Connection URL
+    id: DATABASE_URL
+    label: DATABASE_URL
+    required: false
+    type: string
+  - default: redis://docmost-redis:6379
+    description: Redis Connection URL
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: gxahngf9wc9ak9ahgpjp03zp1akcr7ry
+    description: Application Secret Key
+    id: APP_SECRET
+    label: APP_SECRET
+    required: false
+    type: password
+  - default: docmost
+    description: PostgreSQL User
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: jcui51lw747yuuk4zrpm
+    description: PostgreSQL Password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: docmost
+    description: PostgreSQL Database Name
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/docmost/docker-compose.yml
+++ b/sources/casaos-official/apps/docmost/docker-compose.yml
@@ -1,0 +1,33 @@
+name: docmost
+services:
+  docmost:
+    environment:
+      APP_SECRET: ${APP_SECRET}
+      APP_URL: ${APP_URL}
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+    image: docmost/docmost:0.21.0
+    ports:
+    - protocol: tcp
+      published: 3000
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/storage
+      target: /app/data/storage
+      type: bind
+  docmost-db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: postgres:16-alpine
+    volumes:
+    - source: /AppData/$AppID/pgdata
+      target: /var/lib/postgresql/data
+      type: bind
+  docmost-redis:
+    image: redis:7.2-alpine
+    volumes:
+    - source: /AppData/$AppID/redis
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/docmost/metadata.yaml
+++ b/sources/casaos-official/apps/docmost/metadata.yaml
@@ -1,0 +1,72 @@
+architecture: all
+debian_section: text
+description: A modern wiki and knowledge base for teams
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/icon.png
+license: Unknown
+long_description: 'Docmost is a self-hosted collaborative wiki and documentation tool
+  designed for real-time collaboration, allowing multiple users to edit the same page
+  simultaneously without conflicts. Its intuitive interface is ideal for teams managing
+  knowledge bases, project documentation, or wikis, offering an efficient knowledge
+  creation and sharing experience.
+
+
+  The tool''s core features include real-time collaborative editing and space organization.
+  It supports multiple users editing pages in real time for seamless collaboration
+  and organizes pages into ''spaces'' for teams, projects, or departments, each with
+  independent permission settings. A rich text editor with Markdown shortcuts simplifies
+  content creation. Built-in Draw.io, Excalidraw, and Mermaid tools provide robust
+  diagramming capabilities.
+
+
+  It offers permissions management, assigning access via user groups for content security.
+  Pages can be publicly shared via links for external access. Comments enhance communication
+  and feedback, while page history tracks changes. Features like nested navigation,
+  quick search, file attachments, and Markdown/HTML import/export are supported. The
+  tool’s collaboration and flexibility deliver a modern documentation solution.
+
+
+  **Key Features:**
+
+  - Real-time collaborative editing for multiple users
+
+  - Spaces for organizing pages by team, project or department
+
+  - Permissions management with user group access control
+
+  - Rich text editor with Markdown shortcuts
+
+  - Built-in Draw.io, Excalidraw, Mermaid diagramming tools
+
+  - Public page sharing via links
+
+  - Page comments for communication and feedback
+
+  - Page history, nested navigation, search, and file attachments
+
+
+  **Learn More:**
+
+  - [Docmost Official Website](https://docmost.com/)
+
+  - [Docmost GitHub](https://github.com/docmost/docmost)
+
+  '
+maintainer: docmost <auto-converted@casaos.io>
+name: docmost
+package_name: casaos-docmost-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-6.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-7.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-8.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-9.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Docmost/screenshot-10.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/downtify/config.yml
+++ b/sources/casaos-official/apps/downtify/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: specify a timezone to use, see this list.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/downtify/docker-compose.yml
+++ b/sources/casaos-official/apps/downtify/docker-compose.yml
@@ -1,0 +1,16 @@
+name: downtify
+services:
+  downtify:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: ghcr.io/henriquesebastiao/downtify:1.1.1
+    ports:
+    - protocol: tcp
+      published: 8582
+      target: 8000
+    volumes:
+    - source: /Downloads/downtify
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/downtify/metadata.yaml
+++ b/sources/casaos-official/apps/downtify/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: misc
+description: Download Spotify music with album art and metadata
+homepage: null
+icon: https://raw.githubusercontent.com/henriquesebastiao/downtify/refs/heads/main/assets/casaos-icon.png
+license: Unknown
+long_description: 'With Downtify you can download Spotify musics containing album
+  art, track names, album title and other metadata about the songs. Just copy the
+  Spotify link, whether it''s a single song, an album, etc. As soon as your downloads
+  are complete you will be notified!
+
+  '
+maintainer: Henrique Sebastião <auto-converted@casaos.io>
+name: downtify
+package_name: casaos-downtify-container
+screenshots:
+- https://raw.githubusercontent.com/henriquesebastiao/downtify/refs/heads/main/assets/screenshot-1.png
+- https://raw.githubusercontent.com/henriquesebastiao/downtify/refs/heads/main/assets/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/duckdns/config.yml
+++ b/sources/casaos-official/apps/duckdns/config.yml
@@ -1,0 +1,60 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Etc/UTC
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: subdomain1,subdomain2
+    description: ''
+    id: SUBDOMAINS
+    label: SUBDOMAINS
+    required: false
+    type: string
+  - default: ipv6
+    description: ''
+    id: UPDATE_IP
+    label: UPDATE_IP
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: LOG_FILE
+    label: LOG_FILE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: token
+    description: ''
+    id: TOKEN
+    label: TOKEN
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/duckdns/docker-compose.yml
+++ b/sources/casaos-official/apps/duckdns/docker-compose.yml
@@ -1,0 +1,16 @@
+name: duckdns
+services:
+  duckdns:
+    environment:
+      LOG_FILE: ${LOG_FILE}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      SUBDOMAINS: ${SUBDOMAINS}
+      TOKEN: ${TOKEN}
+      TZ: ${TZ}
+      UPDATE_IP: ${UPDATE_IP}
+    image: lscr.io/linuxserver/duckdns:latest
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/duckdns/metadata.yaml
+++ b/sources/casaos-official/apps/duckdns/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: utils
+description: Dynamic DNS for your domain, supporting both IPv4 and IPv6
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/DuckDNS/icon.png
+license: Unknown
+long_description: duckdns is a DDNS (Dynamic DNS) application that dynamically binds
+  IP addresses to domain names, supporting both IPv4 and IPv6.
+maintainer: DuckDNS Team <auto-converted@casaos.io>
+name: duckdns
+package_name: casaos-duckdns-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/DuckDNS/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/duplicati/config.yml
+++ b/sources/casaos-official/apps/duplicati/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/duplicati/docker-compose.yml
+++ b/sources/casaos-official/apps/duplicati/docker-compose.yml
@@ -1,0 +1,22 @@
+name: duplicati
+services:
+  duplicati:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/duplicati:2.1.0
+    ports:
+    - protocol: tcp
+      published: 8200
+      target: 8200
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Duplicati/backups
+      target: /backups
+      type: bind
+    - source: /Duplicati/source
+      target: /source
+      type: bind

--- a/sources/casaos-official/apps/duplicati/metadata.yaml
+++ b/sources/casaos-official/apps/duplicati/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: net
+description: Store securely encrypted backups in the cloud!
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Duplicati/icon.png
+license: Unknown
+long_description: Duplicati is a free, open source, backup client that securely stores
+  encrypted, incremental, compressed backups on cloud storage services and remote
+  file servers.
+maintainer: duplicati <auto-converted@casaos.io>
+name: duplicati
+package_name: casaos-duplicati-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Duplicati/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Duplicati/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Duplicati/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/emby-nvidia/config.yml
+++ b/sources/casaos-official/apps/emby-nvidia/config.yml
@@ -1,0 +1,44 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: 'true'
+    description: ''
+    id: CPU_FALLBACK
+    label: CPU_FALLBACK
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: NVIDIA_VISIBLE_DEVICES
+    label: NVIDIA_VISIBLE_DEVICES
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/emby-nvidia/docker-compose.yml
+++ b/sources/casaos-official/apps/emby-nvidia/docker-compose.yml
@@ -1,0 +1,27 @@
+name: emby-nvidia
+services:
+  emby:
+    environment:
+      CPU_FALLBACK: ${CPU_FALLBACK}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/emby:4.8.10
+    ports:
+    - protocol: tcp
+      published: 8096
+      target: 8096
+    - protocol: tcp
+      published: 8920
+      target: 8920
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/TV Shows
+      target: /data/tvshows
+      type: bind
+    - source: /Media/Movies
+      target: /data/movies
+      type: bind

--- a/sources/casaos-official/apps/emby-nvidia/metadata.yaml
+++ b/sources/casaos-official/apps/emby-nvidia/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: video
+description: TAKE YOUR MEDIA ANYWHERE WITH EMBY
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/icon.png
+license: Unknown
+long_description: Bringing all of your home videos, music, and photos together into
+  one place has never been easier. Your personal Emby Server automatically converts
+  and streams your media on-the-fly to play on any device.
+maintainer: linuxserver <auto-converted@casaos.io>
+name: emby-nvidia
+package_name: casaos-emby-nvidia-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/emby/config.yml
+++ b/sources/casaos-official/apps/emby/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/emby/docker-compose.yml
+++ b/sources/casaos-official/apps/emby/docker-compose.yml
@@ -1,0 +1,25 @@
+name: emby
+services:
+  emby:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/emby:4.8.10
+    ports:
+    - protocol: tcp
+      published: 8096
+      target: 8096
+    - protocol: tcp
+      published: 8920
+      target: 8920
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/TV Shows
+      target: /data/tvshows
+      type: bind
+    - source: /Media/Movies
+      target: /data/movies
+      type: bind

--- a/sources/casaos-official/apps/emby/metadata.yaml
+++ b/sources/casaos-official/apps/emby/metadata.yaml
@@ -1,0 +1,67 @@
+architecture: all
+debian_section: video
+description: Emby brings together your personal videos, music, photos, and live television.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/icon.png
+license: Unknown
+long_description: 'Emby is a personal media management platform that brings home videos,
+  music, and photos together, automatically converting and streaming to any device.
+  An intuitive design makes it ideal for users to enjoy media content anytime, anywhere,
+  meeting family entertainment and media management needs.
+
+
+  Core features include cross-device media streaming and easy access. It supports
+  real-time conversion and streaming of personal media to any device for seamless
+  playback. A connection service enables easy media access while away from home. Live
+  TV functionality supports streaming, managing DVR, and accessing a library of recordings.
+  Mobile sync delivers media to smartphones and tablets for offline access, automatically
+  updating new content.
+
+
+  It offers parental controls to restrict children''s content access, set schedules
+  and time limits, and remotely monitor sessions. Chromecast support enables easy
+  streaming of videos, music, photos, and Live TV. Content is presented elegantly,
+  enhancing visual experience. Cloud sync supports backup, archiving, and multi-resolution
+  storage for optimized streaming. Web-based media management facilitates editing
+  metadata, images, and searching subtitles, while DLNA integration auto-detects network
+  devices for content streaming. With convenience and versatility at the core, the
+  platform delivers a modern media management solution.
+
+
+  **Key Features:**
+
+  - Automatic conversion and streaming of media to any device
+
+  - Easy access via connection service while away from home
+
+  - Live TV streaming, DVR management, and recording library access
+
+  - Mobile sync to smartphones and tablets for offline access
+
+  - Parental controls with content restrictions, schedules, and remote monitoring
+
+  - Chromecast support for streaming videos, music, photos, and Live TV
+
+  - Cloud sync for backup and multi-resolution storage
+
+  - Web-based media management for editing metadata and searching subtitles
+
+  - DLNA integration for auto-detecting network devices and streaming content
+
+
+  **Learn More:**
+
+  - [Emby Official Website](https://emby.media/)
+
+  '
+maintainer: linuxserver <auto-converted@casaos.io>
+name: emby
+package_name: casaos-emby-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Emby/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/embystat/config.yml
+++ b/sources/casaos-official/apps/embystat/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/embystat/docker-compose.yml
+++ b/sources/casaos-official/apps/embystat/docker-compose.yml
@@ -1,0 +1,16 @@
+name: embystat
+services:
+  embystat:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/embystat:0.2.0
+    ports:
+    - protocol: tcp
+      published: 6555
+      target: 6555
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/embystat/metadata.yaml
+++ b/sources/casaos-official/apps/embystat/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: video
+description: Calculate all kinds of statistics from your (local) Emby or Jellyfin
+  server
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Embystat/icon.png
+license: Unknown
+long_description: EmbyStat is a personal web server that can calculate all kinds of
+  statistics from your (local) Emby or Jellyfin server. Just install this on your
+  server and let him calculate all kinds of fun stuff. This project is still in Alpha
+  phase, but feel free to pull in on your computer and test it out yourself. When
+  the time is right I will host a full informational website/release for common platforms
+  and Wiki pages.
+maintainer: Embystart Team <auto-converted@casaos.io>
+name: embystat
+package_name: casaos-embystat-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Embystat/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Embystat/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Embystat/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/emulatorjs/config.yml
+++ b/sources/casaos-official/apps/emulatorjs/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: /
+    description: ''
+    id: SUBFOLDER
+    label: SUBFOLDER
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/emulatorjs/docker-compose.yml
+++ b/sources/casaos-official/apps/emulatorjs/docker-compose.yml
@@ -1,0 +1,29 @@
+name: emulatorjs
+services:
+  emulatorjs:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      SUBFOLDER: ${SUBFOLDER}
+      TZ: ${TZ}
+    image: linuxserver/emulatorjs:1.9.2
+    ports:
+    - protocol: tcp
+      published: 3001
+      target: 3000
+    - protocol: tcp
+      published: 4001
+      target: 4001
+    - protocol: tcp
+      published: 88
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/ROMS/nes
+      target: /data/nes/roms
+      type: bind

--- a/sources/casaos-official/apps/emulatorjs/metadata.yaml
+++ b/sources/casaos-official/apps/emulatorjs/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: utils
+description: CasaOS Container App for emulatorjs
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/EmulatorJS/icon.png
+license: Unknown
+long_description: EmulatorJS is a Docker-based emulator application that can simulate
+  various operating systems and device environments within containers for development,
+  testing, and learning purposes.
+maintainer: Unknown <auto-converted@casaos.io>
+name: emulatorjs
+package_name: casaos-emulatorjs-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/EmulatorJS/screenshot-1.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/esphome/config.yml
+++ b/sources/casaos-official/apps/esphome/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: 'false'
+    description: Ping IP addresses instead of mDNS
+    id: ESPHOME_DASHBOARD_USE_PING
+    label: ESPHOME_DASHBOARD_USE_PING
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/esphome/docker-compose.yml
+++ b/sources/casaos-official/apps/esphome/docker-compose.yml
@@ -1,0 +1,15 @@
+name: esphome
+services:
+  esphome:
+    environment:
+      ESPHOME_DASHBOARD_USE_PING: ${ESPHOME_DASHBOARD_USE_PING}
+      TZ: ${TZ}
+    image: ghcr.io/esphome/esphome:2025.2
+    ports:
+    - protocol: tcp
+      published: 6052
+      target: 6052
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/esphome/metadata.yaml
+++ b/sources/casaos-official/apps/esphome/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: misc
+description: Home Automation systems
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ESPHome/icon.png
+license: Unknown
+long_description: ESPHome is a system to control your microcontrollers by simple yet
+  powerful configuration files and control them remotely through Home Automation systems.
+maintainer: Unknown <auto-converted@casaos.io>
+name: esphome
+package_name: casaos-esphome-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ESPHome/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ESPHome/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/excalidraw/config.yml
+++ b/sources/casaos-official/apps/excalidraw/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/excalidraw/docker-compose.yml
+++ b/sources/casaos-official/apps/excalidraw/docker-compose.yml
@@ -1,0 +1,8 @@
+name: excalidraw
+services:
+  excalidraw:
+    image: excalidraw/excalidraw:latest
+    ports:
+    - protocol: tcp
+      published: 17638
+      target: 80

--- a/sources/casaos-official/apps/excalidraw/metadata.yaml
+++ b/sources/casaos-official/apps/excalidraw/metadata.yaml
@@ -1,0 +1,68 @@
+architecture: all
+debian_section: utils
+description: Virtual whiteboard for sketching hand-drawn like diagrams
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/icon.png
+license: Unknown
+long_description: 'Excalidraw is a virtual hand-drawn style whiteboard platform supporting
+  infinite canvas and end-to-end encrypted collaboration. An intuitive interface offers
+  a hand-drawn experience, ideal for brainstorming, design sketches, or educational
+  scenarios, meeting diverse creative needs.
+
+
+  Core features include an infinite canvas whiteboard and end-to-end encrypted collaboration.
+  Hand-drawn style with shape library support allows creating rich graphics, enhanced
+  by image insertion capabilities. Dark mode improves user experience, catering to
+  diverse users.
+
+
+  It provides export options including PNG, SVG, and clipboard for easy content sharing.
+  Drawing capabilities cover rectangle, circle, diamond, arrow, line, free-draw, and
+  eraser, with arrow-binding and labeled arrow support. Undo, redo, zoom, and panning
+  functionalities optimize operations. With creativity and security at the core, the
+  platform delivers a modern whiteboard design solution.
+
+
+  **Key Features:**
+
+  - Infinite canvas whiteboard supporting hand-drawn style
+
+  - Shape library support for creating rich graphics
+
+  - Image insertion capability
+
+  - Dark mode
+
+  - Export to PNG, SVG, and clipboard
+
+  - Open format - export drawings as an `.excalidraw` json file
+
+  - Wide range of tools - rectangle, circle, diamond, arrow, line, free-draw, eraser...
+
+  - Arrow-binding & labeled arrows
+
+  - Undo and redo
+
+  - Zoom and panning support
+
+
+  **Learn More:**
+
+  - [Excalidraw Official Website](https://excalidraw.com/)
+
+  - [Excalidraw GitHub](https://github.com/excalidraw/excalidraw)
+
+  '
+maintainer: excalidraw <auto-converted@casaos.io>
+name: excalidraw
+package_name: casaos-excalidraw-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Excalidraw/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/filebrowser/config.yml
+++ b/sources/casaos-official/apps/filebrowser/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run FileBrowser as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run FileBrowser as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/filebrowser/docker-compose.yml
+++ b/sources/casaos-official/apps/filebrowser/docker-compose.yml
@@ -1,0 +1,19 @@
+name: filebrowser
+services:
+  filebrowser:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: filebrowser/filebrowser:v2.23.0
+    ports:
+    - protocol: tcp
+      published: 10180
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/db
+      target: /db
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /srv
+      type: bind

--- a/sources/casaos-official/apps/filebrowser/metadata.yaml
+++ b/sources/casaos-official/apps/filebrowser/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: net
+description: Upload, delete, preview, rename, edit and share your files.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileBrowser/icon.png
+license: Unknown
+long_description: File Browser - Webbased File Browser including sharing functions
+  etc.
+maintainer: File Browser <auto-converted@casaos.io>
+name: filebrowser
+package_name: casaos-filebrowser-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileBrowser/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileBrowser/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileBrowser/screenshot-3.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/filedrop/config.yml
+++ b/sources/casaos-official/apps/filedrop/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: specify a timezone to use, see this list.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/filedrop/docker-compose.yml
+++ b/sources/casaos-official/apps/filedrop/docker-compose.yml
@@ -1,0 +1,16 @@
+name: filedrop
+services:
+  filedrop:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: noecl/filedrop:1.0.1
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/data
+      target: /var/file_drop_files
+      type: bind

--- a/sources/casaos-official/apps/filedrop/metadata.yaml
+++ b/sources/casaos-official/apps/filedrop/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: net
+description: FileDrop is a free, open source file sharing service
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Filedrop/icon.png
+license: Unknown
+long_description: 'FileDrop is a self-hosted file sharing service that allows you
+  to easily share files with family, friends, or colleagues. It''s been designed to
+  be easy to use and light on resources.
+
+  '
+maintainer: Noé Favier (noe.favier@outlook.com) <auto-converted@casaos.io>
+name: filedrop
+package_name: casaos-filedrop-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Filedrop/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/fileflows/config.yml
+++ b/sources/casaos-official/apps/fileflows/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/fileflows/docker-compose.yml
+++ b/sources/casaos-official/apps/fileflows/docker-compose.yml
@@ -1,0 +1,31 @@
+name: fileflows
+services:
+  fileflows:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: revenz/fileflows:stable
+    ports:
+    - protocol: tcp
+      published: 19200
+      target: 5000
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /app/Data
+      type: bind
+    - source: /AppData/$AppID/logs
+      target: /app/Logs
+      type: bind
+    - source: /AppData/$AppID/common
+      target: /app/common
+      type: bind
+    - source: /AppData/$AppID/temp
+      target: /temp
+      type: bind
+    - source: /Media
+      target: /Media
+      type: bind
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind

--- a/sources/casaos-official/apps/fileflows/metadata.yaml
+++ b/sources/casaos-official/apps/fileflows/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: video
+description: File processing made easy!
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileFlows/icon.png
+license: Unknown
+long_description: 'Save storage space with efficient file processing.
+
+
+  FileFlows lets you monitor and process any file type with custom flows. Videos,
+  audio, images, archives, comics, eBooks—you name it!
+
+  '
+maintainer: FileFlows <auto-converted@casaos.io>
+name: fileflows
+package_name: casaos-fileflows-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileFlows/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileFlows/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FileFlows/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/firefly/config.yml
+++ b/sources/casaos-official/apps/firefly/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: firefly
+    description: ''
+    id: FIREFLY_PASSWORD
+    label: FIREFLY_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/firefly/docker-compose.yml
+++ b/sources/casaos-official/apps/firefly/docker-compose.yml
@@ -1,0 +1,13 @@
+name: firefly
+services:
+  firefly:
+    environment:
+      FIREFLY_PASSWORD: ${FIREFLY_PASSWORD}
+    image: uusec/firefly:latest
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/lib/modules
+      target: /lib/modules
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/conf
+      target: /firefly/conf
+      type: bind

--- a/sources/casaos-official/apps/firefly/metadata.yaml
+++ b/sources/casaos-official/apps/firefly/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: net
+description: Firefly, the easiest using of WireGuard VPN server, plus version of wg-easy.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Firefly/icon.png
+license: Unknown
+long_description: Firefly is a simple and easy to install WireGuard server software,
+  which can be widely used in scenarios such as remote networking, remote work, and
+  expose a local server behind a NAT or firewall to the internet.  🎯 Features 🟢 Provide
+  a simple and easy-to-use web management UI  🟣 Supports access to all WireGuard clients  🟡
+  No need for system installation of WireGuard components  🟠 Single file, no additional
+  library dependencies  🔴 Automatically apply for free SSL certificate
+maintainer: Safe3 <auto-converted@casaos.io>
+name: firefly
+package_name: casaos-firefly-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Firefly/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/flaresolverr/config.yml
+++ b/sources/casaos-official/apps/flaresolverr/config.yml
@@ -1,0 +1,56 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: '002'
+    description: ''
+    id: UMASK
+    label: UMASK
+    required: false
+    type: string
+  - default: info
+    description: ''
+    id: LOG_LEVEL
+    label: LOG_LEVEL
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: LOG_HTML
+    label: LOG_HTML
+    required: false
+    type: string
+  - default: none
+    description: ''
+    id: CAPTCHA_SOLVER
+    label: CAPTCHA_SOLVER
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/flaresolverr/docker-compose.yml
+++ b/sources/casaos-official/apps/flaresolverr/docker-compose.yml
@@ -1,0 +1,16 @@
+name: flaresolverr
+services:
+  flaresolverr:
+    environment:
+      CAPTCHA_SOLVER: ${CAPTCHA_SOLVER}
+      LOG_HTML: ${LOG_HTML}
+      LOG_LEVEL: ${LOG_LEVEL}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+      UMASK: ${UMASK}
+    image: ghcr.io/flaresolverr/flaresolverr:v3.3.25
+    ports:
+    - protocol: tcp
+      published: 8191
+      target: 8191

--- a/sources/casaos-official/apps/flaresolverr/metadata.yaml
+++ b/sources/casaos-official/apps/flaresolverr/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: net
+description: CasaOS Container App for flaresolverr
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlareSolverr/icon.png
+license: Unknown
+long_description: CasaOS Container App for flaresolverr
+maintainer: Unknown <auto-converted@casaos.io>
+name: flaresolverr
+package_name: casaos-flaresolverr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlareSolverr/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/flowise/config.yml
+++ b/sources/casaos-official/apps/flowise/config.yml
@@ -1,0 +1,64 @@
+groups:
+- description: null
+  fields:
+  - default: '3025'
+    description: ''
+    id: PORT
+    label: PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: /root/.flowise
+    description: ''
+    id: DATABASE_PATH
+    label: DATABASE_PATH
+    required: false
+    type: path
+  - default: /root/.flowise
+    description: ''
+    id: APIKEY_PATH
+    label: APIKEY_PATH
+    required: false
+    type: path
+  - default: /root/.flowise
+    description: ''
+    id: SECRETKEY_PATH
+    label: SECRETKEY_PATH
+    required: false
+    type: path
+  - default: /root/.flowise/logs
+    description: ''
+    id: LOG_PATH
+    label: LOG_PATH
+    required: false
+    type: path
+  - default: /root/.flowise/storage
+    description: ''
+    id: BLOB_STORAGE_PATH
+    label: BLOB_STORAGE_PATH
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+- description: null
+  fields:
+  - default: casaos
+    description: ''
+    id: FLOWISE_USERNAME
+    label: FLOWISE_USERNAME
+    required: false
+    type: string
+  - default: casaos
+    description: ''
+    id: FLOWISE_PASSWORD
+    label: FLOWISE_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/flowise/docker-compose.yml
+++ b/sources/casaos-official/apps/flowise/docker-compose.yml
@@ -1,0 +1,23 @@
+name: flowise
+services:
+  flowise:
+    entrypoint:
+    - /bin/sh -c "sleep 3; flowise start"
+    environment:
+      APIKEY_PATH: ${APIKEY_PATH}
+      BLOB_STORAGE_PATH: ${BLOB_STORAGE_PATH}
+      DATABASE_PATH: ${DATABASE_PATH}
+      FLOWISE_PASSWORD: ${FLOWISE_PASSWORD}
+      FLOWISE_USERNAME: ${FLOWISE_USERNAME}
+      LOG_PATH: ${LOG_PATH}
+      PORT: ${PORT}
+      SECRETKEY_PATH: ${SECRETKEY_PATH}
+    image: flowiseai/flowise:3.0.4
+    ports:
+    - protocol: tcp
+      published: 3025
+      target: 3025
+    volumes:
+    - source: /AppData/$AppID
+      target: /root/.flowise
+      type: bind

--- a/sources/casaos-official/apps/flowise/metadata.yaml
+++ b/sources/casaos-official/apps/flowise/metadata.yaml
@@ -1,0 +1,87 @@
+architecture: all
+debian_section: devel
+description: An open source generative AI development platform for building AI Agents
+  and...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlowiseAi/icon.png
+license: Unknown
+long_description: 'An open source generative AI development platform for building
+  AI Agents and LLM workflows
+
+
+  Flowise is a generative AI development platform for building AI agents and LLM workflows.
+  An intuitive interface with a visual editor simplifies complex workflow design,
+  ideal for developers creating diverse AI applications, from chatbots to data processing
+  pipelines.
+
+
+  Core features include visual orchestration and data integration. Support for various
+  models, custom code, and branching, looping, and routing logic enables complex workflow
+  creation. Connection to over 100 data sources, vector databases, and memory modules
+  ensures flexible data ingestion. Monitoring capabilities provide execution logs
+  and visual debugging for workflow transparency and maintenance. Self-hosted and
+  air-gapped deployment options accommodate diverse infrastructure needs.
+
+
+  It offers data processing with transforms, filters, aggregates, and RAG indexing
+  pipelines. Memory optimization and planning techniques enhance performance, while
+  MCP integration supports tool connections and authentication. Security controls
+  include role-based access, single sign-on, and encrypted credentials for data protection.
+  API, JavaScript and Python SDKs, and command-line interface enable extensibility,
+  with embedded chat components and a template marketplace accelerating development.
+  Scalability supports high-throughput workflows, and evaluation features optimize
+  performance. With flexibility and efficiency at the core, the platform delivers
+  a modern solution for AI development.
+
+
+  **Key Features:**
+
+  - Visual editor supporting multiple models, custom code, branching looping routing
+  logic
+
+  - Connection to over 100 data sources, vector databases, and memory modules
+
+  - Execution logs and visual debugging for enhanced monitoring
+
+  - Data processing with transforms, filters, aggregates, and RAG indexing pipelines
+
+  - Various memory optimization technique and integrations
+
+  - MCP client and server nodes for tool integration
+
+  - Input moderation and output post-processing for safety
+
+  - API, JavaScript and Python SDKs, and command-line interface
+
+  - Customizable embedded chat components
+
+  - Template marketplace and reusable components
+
+  - Role-based access control, single sign-on, encrypted credentials
+
+  - Vertical and horizontal scalability for high-throughput workflows
+
+  - Datasets and evaluation features for workflow optimization
+
+
+  **Learn More:**
+
+  - [Flowise Official Website](https://flowiseai.com/)
+
+  - [Flowise GitHub](https://github.com/flowiseai/flowise)
+
+  - [Flowise Documentation](https://docs.flowiseai.com/)
+
+  '
+maintainer: Flowise <auto-converted@casaos.io>
+name: flowise
+package_name: casaos-flowise-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlowiseAi/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlowiseAi/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlowiseAi/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FlowiseAi/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/freshrss/config.yml
+++ b/sources/casaos-official/apps/freshrss/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: ''
+    description: Set the container timezone with this (default is ``UTC``).
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: 1,31
+    description: Set cron job interval to refresh feeds.
+    id: CRON_MIN
+    label: CRON_MIN
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/freshrss/docker-compose.yml
+++ b/sources/casaos-official/apps/freshrss/docker-compose.yml
@@ -1,0 +1,18 @@
+name: freshrss
+services:
+  freshrss:
+    environment:
+      CRON_MIN: ${CRON_MIN}
+      TZ: ${TZ}
+    image: freshrss/freshrss:1.26.0
+    ports:
+    - protocol: tcp
+      published: 8749
+      target: 80
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/data
+      target: /var/www/FreshRSS/data
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/extensions
+      target: /var/www/FreshRSS/extensions
+      type: bind

--- a/sources/casaos-official/apps/freshrss/metadata.yaml
+++ b/sources/casaos-official/apps/freshrss/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: utils
+description: A free, self-hostable news aggregator…
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FreshRSS/icon.png
+license: Unknown
+long_description: FreshRSS is a self-hosted RSS and Atom feed aggregator. It is lightweight,
+  easy to work with, powerful, and customizable.
+maintainer: FreshRSS <auto-converted@casaos.io>
+name: freshrss
+package_name: casaos-freshrss-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/FreshRSS/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/gateway-go/config.yml
+++ b/sources/casaos-official/apps/gateway-go/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/gateway-go/docker-compose.yml
+++ b/sources/casaos-official/apps/gateway-go/docker-compose.yml
@@ -1,0 +1,12 @@
+name: gateway-go
+services:
+  gateway-go:
+    image: openiothub/gateway-go:v2.0.10
+    ports:
+    - protocol: tcp
+      published: 34323
+      target: 34323
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /root
+      type: bind

--- a/sources/casaos-official/apps/gateway-go/metadata.yaml
+++ b/sources/casaos-official/apps/gateway-go/metadata.yaml
@@ -1,0 +1,29 @@
+architecture: all
+debian_section: net
+description: A third-party client for casaos and zimaOS, remote access management
+  interface
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gateway-go/icon.png
+license: Unknown
+long_description: 'A third-party client for casaos and zimaOS, remote access management
+  interface, remote access to installed applications.
+
+
+  A fast reverse proxy to help you expose a local server behind a NAT or firewall
+  to your client, remote access all your casaos/zimaos apps.
+
+
+  Use OpenIoTHub to scan the following QR code add a gateway,then add host,add casaos/zimaos
+  host''s web page port,finally, enjoy remote control
+
+  '
+maintainer: iotserv <auto-converted@casaos.io>
+name: gateway-go
+package_name: casaos-gateway-go-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gateway-go/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gateway-go/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/gitea/config.yml
+++ b/sources/casaos-official/apps/gitea/config.yml
@@ -1,0 +1,18 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: The GID (Unix group ID) of the user that runs Gitea
+    id: USER_GID
+    label: USER_GID
+    required: false
+    type: string
+  - default: '1000'
+    description: The UID (Unix user ID) of the user that runs Gitea
+    id: USER_UID
+    label: USER_UID
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/gitea/docker-compose.yml
+++ b/sources/casaos-official/apps/gitea/docker-compose.yml
@@ -1,0 +1,18 @@
+name: gitea
+services:
+  gitea:
+    environment:
+      USER_GID: ${USER_GID}
+      USER_UID: ${USER_UID}
+    image: gitea/gitea:1.24.6
+    ports:
+    - protocol: tcp
+      published: 3002
+      target: 3000
+    - protocol: tcp
+      published: 222
+      target: 22
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/gitea/metadata.yaml
+++ b/sources/casaos-official/apps/gitea/metadata.yaml
@@ -1,0 +1,52 @@
+architecture: all
+debian_section: devel
+description: Self-hosted software development service
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gitea/icon.png
+license: Unknown
+long_description: "Gitea is a painless self-hosted all-in-one software development\
+  \ service, it includes Git hosting, code review, team collaboration, package registry\
+  \ and CI/CD. It is similar to GitHub, Bitbucket and GitLab. \n\n- Code Hosting\n\
+  Gitea supports creating and managing repositories, browsing commit history and code\
+  \ files, reviewing and merging code submissions, managing collaborators, handling\
+  \ branches, and more. It also supports many common Git features such as tags, Cherry-pick,\
+  \ hooks, integrated collaboration tools, and more.\n\n- Lightweight and Fast\nOne\
+  \ of Gitea's design goals is to be lightweight and fast in response. Unlike some\
+  \ large code hosting platforms, it remains lean, performing well in terms of speed,\
+  \ and is suitable for resource-limited server environments. Due to its lightweight\
+  \ design, Gitea has relatively low resource consumption and performs well in resource-constrained\
+  \ environments.\n\n- Easy Deployment and Maintenance\nIt can be easily deployed\
+  \ on various servers without complex configurations or dependencies. This makes\
+  \ it convenient for individual developers or small teams to set up and manage their\
+  \ own Git services.\n\n- Security\nGitea places a strong emphasis on security, offering\
+  \ features such as user permission management, access control lists, and more to\
+  \ ensure the security of code and data.\n\n- Code Review\nCode review supports both\
+  \ the Pull Request workflow and AGit workflow. Reviewers can browse code online\
+  \ and provide review comments or feedback. Submitters can receive review comments\
+  \ and respond or modify code online. Code reviews can help individuals and organizations\
+  \ enhance code quality.\n\n- CI/CD\nGitea Actions supports CI/CD functionality,\
+  \ compatible with GitHub Actions. Users can write workflows in familiar YAML format\
+  \ and reuse a variety of existing Actions plugins. Actions plugins support downloading\
+  \ from any Git website.\n\n- Project Management\nGitea tracks project requirements,\
+  \ features, and bugs through columns and issues. Issues support features like branches,\
+  \ tags, milestones, assignments, time tracking, due dates, dependencies, and more.\n\
+  \n- Artifact Repository\nGitea supports over 20 different types of public or private\
+  \ software package management, including Cargo, Chef, Composer, Conan, Conda, Container,\
+  \ Helm, Maven, npm, NuGet, Pub, PyPI, RubyGems, Vagrant, and more.\n\n- Open Source\
+  \ Community Support\nGitea is an open-source project based on the MIT license. It\
+  \ has an active open-source community that continuously develops and improves the\
+  \ platform. The project also actively welcomes community contributions, ensuring\
+  \ updates and innovation.\n\n- Multilingual Support\nGitea provides interfaces in\
+  \ multiple languages, catering to users globally and promoting internationalization\
+  \ and localization.\n"
+maintainer: Gitea <auto-converted@casaos.io>
+name: gitea
+package_name: casaos-gitea-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gitea/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gitea/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gitea/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/glances/config.yml
+++ b/sources/casaos-official/apps/glances/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: -w
+    description: Glances mode
+    id: GLANCES_OPT
+    label: GLANCES_OPT
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/glances/docker-compose.yml
+++ b/sources/casaos-official/apps/glances/docker-compose.yml
@@ -1,0 +1,20 @@
+name: glances
+services:
+  glances:
+    environment:
+      GLANCES_OPT: ${GLANCES_OPT}
+    image: nicolargo/glances:4.3.0.8-full
+    ports:
+    - protocol: tcp
+      published: 61208
+      target: 61208
+    - protocol: tcp
+      published: 61209
+      target: 61209
+    volumes:
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/mnt
+      target: /mnt
+      type: bind

--- a/sources/casaos-official/apps/glances/metadata.yaml
+++ b/sources/casaos-official/apps/glances/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: misc
+description: Cross-platform monitoring tool.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Glances/icon.png
+license: Unknown
+long_description: Glances is an open-source system cross-platform monitoring tool.
+  It allows real-time monitoring of various aspects of your system such as CPU, memory,
+  disk, network usage etc.
+maintainer: Nicolas Hennion <auto-converted@casaos.io>
+name: glances
+package_name: casaos-glances-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Glances/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/gopeed/config.yml
+++ b/sources/casaos-official/apps/gopeed/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/gopeed/docker-compose.yml
+++ b/sources/casaos-official/apps/gopeed/docker-compose.yml
@@ -1,0 +1,15 @@
+name: gopeed
+services:
+  gopeed:
+    image: liwei2633/gopeed:v1.7.1
+    ports:
+    - protocol: tcp
+      published: 9999
+      target: 9999
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /app/storage
+      type: bind
+    - source: /Downloads
+      target: /app/Downloads
+      type: bind

--- a/sources/casaos-official/apps/gopeed/metadata.yaml
+++ b/sources/casaos-official/apps/gopeed/metadata.yaml
@@ -1,0 +1,62 @@
+architecture: all
+debian_section: utils
+description: Open source, lightweight, native, supports (HTTP, BitTorrent, Magnet
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gopeed/icon.png
+license: Unknown
+long_description: 'Open source, lightweight, native, supports (HTTP, BitTorrent, Magnet,
+  etc.) for downloading.
+
+
+  Gopeed is a modern high-speed download tool supporting HTTP, BitTorrent, and Magnet
+  protocols, offering a beautiful interface and powerful functionality. Its lightweight
+  design and multi-platform support make it ideal for efficient file downloading across
+  various devices.
+
+
+  The tool''s core features include high-speed downloading and an elegant interface.
+  It leverages Golang coroutines for concurrent downloading, supporting HTTP, HTTPS,
+  BitTorrent, and Magnet protocols for fast, stable performance. The interface follows
+  Material Design standards, including a dark mode, balancing aesthetics and usability.
+  Advanced features include seeding, DHT, PEX, uTP, Webtorrent, and UPnP support,
+  with daily automatic tracker list updates to enhance download efficiency.
+
+
+  It provides a RESTful API for open integration, allowing users to remotely control
+  download tasks, pause, or delete them. Decentralized extensions enable JavaScript
+  plugins to enhance functionality, such as downloading videos or music from websites.
+  The tool''s speed, flexibility, and user-friendly design deliver a modern download
+  solution.
+
+
+  **Key Features:**
+
+  - High-speed downloading with HTTP, BitTorrent, Magnet protocols
+
+  - Seeding, DHT, PEX, uTP, Webtorrent, UPnP
+
+  - Daily automatic tracker list updates
+
+  - RESTful API for remote download task control
+
+  - Decentralized extensions with JavaScript plugins
+
+
+  **Learn More:**
+
+  - [Gopeed Official Website](https://gopeed.com)
+
+  - [Gopeed GitHub Repository](https://github.com/gopeedlab/gopeed)
+
+  '
+maintainer: GopeedLab <auto-converted@casaos.io>
+name: gopeed
+package_name: casaos-gopeed-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gopeed/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gopeed/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Gopeed/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/grafana/config.yml
+++ b/sources/casaos-official/apps/grafana/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/grafana/docker-compose.yml
+++ b/sources/casaos-official/apps/grafana/docker-compose.yml
@@ -1,0 +1,12 @@
+name: grafana
+services:
+  grafana:
+    image: grafana/grafana:11.5.2
+    ports:
+    - protocol: tcp
+      published: 3003
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /var/lib/grafana
+      type: bind

--- a/sources/casaos-official/apps/grafana/metadata.yaml
+++ b/sources/casaos-official/apps/grafana/metadata.yaml
@@ -1,0 +1,39 @@
+architecture: all
+debian_section: net
+description: Grafana is a complete observability stack that allows you to monitor
+  and...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Grafana/icon.png
+license: Unknown
+long_description: 'Grafana is a complete observability stack that allows you to monitor
+  and analyze metrics, logs and traces. It allows you to query, visualize, alert on
+  and understand your data no matter where it is stored.
+
+
+
+  Grafana open source is open source visualization and analytics software.Visualizations:
+  Fast and flexible client side graphs with a multitude of options. Panel plugins
+  offer many different ways to visualize metrics and logs. Dynamic Dashboards: Create
+  dynamic & reusable dashboards with template variables that appear as dropdowns at
+  the top of the dashboard. Explore Metrics: Explore your data through ad-hoc queries
+  and dynamic drilldown. Split view and compare different time ranges, queries and
+  data sources side by side. Explore Logs: Experience the magic of switching from
+  metrics to logs with preserved label filters. Quickly search through all your logs
+  or streaming them live. Alerting: Visually define alert rules for your most important
+  metrics. Grafana will continuously evaluate and send notifications to systems like
+  Slack, PagerDuty, VictorOps, OpsGenie. Mixed Data Sources: Mix different data sources
+  in the same graph! You can specify a data source on a per-query basis. This works
+  for even custom datasources.
+
+  '
+maintainer: grafana <auto-converted@casaos.io>
+name: grafana
+package_name: casaos-grafana-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Grafana/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Grafana/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Grafana/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/handbrake/config.yml
+++ b/sources/casaos-official/apps/handbrake/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/handbrake/docker-compose.yml
+++ b/sources/casaos-official/apps/handbrake/docker-compose.yml
@@ -1,0 +1,21 @@
+name: handbrake
+services:
+  handbrake:
+    image: jlesage/handbrake:v25.02.3
+    ports:
+    - protocol: tcp
+      published: 5800
+      target: 5800
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /storage
+      type: bind
+    - source: /AppData/$AppID/watch
+      target: /watch
+      type: bind
+    - source: /Media
+      target: /output
+      type: bind
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/handbrake/metadata.yaml
+++ b/sources/casaos-official/apps/handbrake/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: video
+description: Liberate your videos and unleash infinite possibilities.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Handbrake/icon.png
+license: Unknown
+long_description: Handbrake is a Docker-based application for video transcoding and
+  compression, offering powerful and flexible multimedia processing across multiple
+  platforms.
+maintainer: Unknown <auto-converted@casaos.io>
+name: handbrake
+package_name: casaos-handbrake-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Handbrake/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/holoplay/config.yml
+++ b/sources/casaos-official/apps/holoplay/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/holoplay/docker-compose.yml
+++ b/sources/casaos-official/apps/holoplay/docker-compose.yml
@@ -1,0 +1,8 @@
+name: holoplay
+services:
+  holoplay:
+    image: spout8301/holoplay:1.12.3
+    ports:
+    - protocol: tcp
+      published: 3000
+      target: 3000

--- a/sources/casaos-official/apps/holoplay/metadata.yaml
+++ b/sources/casaos-official/apps/holoplay/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: misc
+description: A web app to listen Youtube audio source.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/icon.png
+license: Unknown
+long_description: HoloPlay is a web based self-hosted using Invidious API for listening
+  Youtube audio source.
+maintainer: Stéphane Richin <auto-converted@casaos.io>
+name: holoplay
+package_name: casaos-holoplay-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-6.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HoloPlay/screenshot-7.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/homeassistant/config.yml
+++ b/sources/casaos-official/apps/homeassistant/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run HomeAssistant as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run HomeAssistant as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/homeassistant/docker-compose.yml
+++ b/sources/casaos-official/apps/homeassistant/docker-compose.yml
@@ -1,0 +1,20 @@
+name: homeassistant
+services:
+  homeassistant:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: homeassistant/home-assistant:2025.7
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - read_only: true
+      source: /etc/localtime
+      target: /etc/localtime
+      type: bind
+    - read_only: true
+      source: ${CONTAINER_DATA_ROOT}/run/dbus
+      target: /run/dbus
+      type: bind

--- a/sources/casaos-official/apps/homeassistant/metadata.yaml
+++ b/sources/casaos-official/apps/homeassistant/metadata.yaml
@@ -1,0 +1,76 @@
+architecture: all
+debian_section: misc
+description: Open source home automation that puts local control and privacy first.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HomeAssistant/icon.png
+license: Unknown
+long_description: 'Home Assistant is a smart home management app prioritizing local
+  control and data privacy, managing devices through an intuitive interface with data
+  stored locally, eliminating cloud dependency. Its robust features and community
+  support make it ideal for DIY enthusiasts and home users creating personalized home
+  experiences.
+
+
+  The app''s core features include customizable dashboards, powerful automations,
+  and a voice assistant. Dashboards support drag-and-drop customization, with various
+  card types to display data and control devices like lights or sensors. It offers
+  an advanced automation engine, such as turning on lights at sunset or alerting users
+  to an open garage door. The Assist voice assistant enables natural language control,
+  compatible with phones, tablets, smartwatches, and even traditional telephones,
+  allowing users to customize interactions and experiment with AI conversations to
+  meet diverse needs.
+
+
+  It extends functionality through add-ons, supporting tools like AdGuard for ad blocking,
+  NodeRed for third-party automations, or turning devices into Spotify Connect targets.
+  Home energy management optimizes solar production and usage planning to save costs.
+  Home Assistant Cast transforms TVs into dashboard displays, and NFC tags trigger
+  music playback or routine automations. Community documentation aids configuration,
+  with local data processing ensuring privacy, suitable for home or small team smart
+  home management.
+
+
+  **Key Features:**
+
+  - Local data storage, prioritizing privacy
+
+  - Drag-and-drop customizable dashboards for device control and data display
+
+  - Advanced automations for triggering smart home events
+
+  - Assist voice assistant for natural language control
+
+  - Add-ons for integrating AdGuard, NodeRed, and more
+
+  - Home energy management for optimized usage and cost savings
+
+  - Home Assistant Cast for TV dashboard displays
+
+  - NFC tags for triggering music or automation tasks
+
+
+  **Learn More:**
+
+  - [Home Assistant Official Website](https://www.home-assistant.io)
+
+  - [Home Assistant GitHub Repository](https://github.com/home-assistant/core)
+
+  - [Home Assistant Documentation](https://www.home-assistant.io/docs)
+
+  - [Home Assistant Community](https://community.home-assistant.io)
+
+  - [Home Assistant Add-ons](https://www.home-assistant.io/addons)
+
+  '
+maintainer: Home Assistant <auto-converted@casaos.io>
+name: homeassistant
+package_name: casaos-homeassistant-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HomeAssistant/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HomeAssistant/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HomeAssistant/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/HomeAssistant/screenshot-4.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/homebridge/config.yml
+++ b/sources/casaos-official/apps/homebridge/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/homebridge/docker-compose.yml
+++ b/sources/casaos-official/apps/homebridge/docker-compose.yml
@@ -1,0 +1,8 @@
+name: homebridge
+services:
+  homebridge:
+    image: homebridge/homebridge:latest
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /homebridge
+      type: bind

--- a/sources/casaos-official/apps/homebridge/metadata.yaml
+++ b/sources/casaos-official/apps/homebridge/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: misc
+description: HomeKit support for the impatient.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Homebridge/icon.png
+license: Unknown
+long_description: Homebridge is a lightweight NodeJS server you can run on your home
+  network that emulates the iOS HomeKit API. It supports Plugins, which are community-contributed
+  modules that provide a basic bridge from HomeKit to various 3rd-party APIs provided
+  by manufacturers of "smart home" devices.
+maintainer: Homebridge <auto-converted@casaos.io>
+name: homebridge
+package_name: casaos-homebridge-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Homebridge/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Homebridge/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/hugo/config.yml
+++ b/sources/casaos-official/apps/hugo/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/hugo/docker-compose.yml
+++ b/sources/casaos-official/apps/hugo/docker-compose.yml
@@ -1,0 +1,18 @@
+name: hugo
+services:
+  hugo:
+    command:
+    - server
+    - --bind=0.0.0.0
+    image: ghcr.io/gohugoio/hugo:v0.148.2
+    ports:
+    - protocol: tcp
+      published: 1313
+      target: 1313
+    volumes:
+    - source: /AppData/$AppID/project
+      target: /project
+      type: bind
+    - source: /AppData/$AppID/cache
+      target: /cache
+      type: bind

--- a/sources/casaos-official/apps/hugo/metadata.yaml
+++ b/sources/casaos-official/apps/hugo/metadata.yaml
@@ -1,0 +1,90 @@
+architecture: all
+debian_section: devel
+description: The world's fastest framework for building websites
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Hugo/icon.png
+license: Unknown
+long_description: 'Hugo is a high-speed static site generation platform written in
+  Go, optimized for speed and designed for flexibility. Advanced templating system
+  and fast asset pipelines render a complete website in seconds, ideal for creating
+  documentation sites, landing pages, and various project websites.
+
+
+  Core features include optimized speed and a flexible framework. Concurrency in Go
+  enables rapid rendering, supporting image processing (convert, resize, crop, rotate,
+  adjust colors, apply filters, overlay text/images, extract EXIF data), JavaScript
+  bundling (tree shaking, code splitting), Sass processing, and TailwindCSS support.
+  Multilingual support and taxonomy system make it suitable for diverse sites like
+  documentation, news, or events.
+
+
+  It includes an embedded web server for real-time previews of content, structure,
+  and style changes during development. Frequent releases ensure ongoing feature enhancements,
+  keeping it cutting-edge. With efficiency and flexibility at the core, the platform
+  delivers a modern static site generation solution.
+
+
+  **Key Features:**
+
+  - High-speed rendering, generating sites in seconds
+
+  - Fast asset pipelines: image processing, JavaScript bundling, Sass, and TailwindCSS
+  support
+
+  - Flexible framework with multilingual and taxonomy systems
+
+  - Embedded web server for real-time development previews
+
+  - Rich ecosystem of themes and plugins
+
+
+
+  **Prerequisites for Using Hugo:**
+
+
+  1. Open command line, navigate to `/DATA/AppData/hugo/project` directory
+
+
+  ```cd /DATA/AppData/hugo/project```
+
+
+  2. Initialize the `project` directory as an empty Git repository
+
+
+  ```git init```
+
+
+  3. Download the Ananke theme
+
+
+  ```git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke```
+
+
+  4. Specify the current theme
+
+
+  ```echo "theme = ''ananke''" >> hugo.toml```
+
+
+  5. Restart Hugo
+
+
+
+  **Learn More:**
+
+  - [Hugo Official Website](https://gohugo.io/)
+
+  - [Hugo GitHub](https://github.com/gohugoio/hugo)
+
+  '
+maintainer: gohugoio <auto-converted@casaos.io>
+name: hugo
+package_name: casaos-hugo-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Hugo/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Hugo/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Hugo/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/icewhale-stable-diffusion-webui/config.yml
+++ b/sources/casaos-official/apps/icewhale-stable-diffusion-webui/config.yml
@@ -1,0 +1,18 @@
+groups:
+- description: null
+  fields:
+  - default: all
+    description: ''
+    id: NVIDIA_VISIBLE_DEVICES
+    label: NVIDIA_VISIBLE_DEVICES
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: CPU_FALLBACK
+    label: CPU_FALLBACK
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/icewhale-stable-diffusion-webui/docker-compose.yml
+++ b/sources/casaos-official/apps/icewhale-stable-diffusion-webui/docker-compose.yml
@@ -1,0 +1,21 @@
+name: icewhale-stable-diffusion-webui
+services:
+  icewhale-stable-diffusion-webui:
+    environment:
+      CPU_FALLBACK: ${CPU_FALLBACK}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES}
+    image: johnguan/stable-diffusion-webui:latest
+    ports:
+    - protocol: tcp
+      published: 7860
+      target: 7860
+    volumes:
+    - source: /AppData/Stable-Diffusion-WebUI/models
+      target: /data/models
+      type: bind
+    - source: /AppData/Stable-Diffusion-WebUI/outputs
+      target: /data/outputs
+      type: bind
+    - source: /AppData/Stable-Diffusion-WebUI/config
+      target: /data/config
+      type: bind

--- a/sources/casaos-official/apps/icewhale-stable-diffusion-webui/metadata.yaml
+++ b/sources/casaos-official/apps/icewhale-stable-diffusion-webui/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: devel
+description: An AI model used to generate images conditioned on text descriptions.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/StableDiffusionWebUI/icon.png
+license: Unknown
+long_description: Stable Diffusion is a deep learning, text-to-image model released
+  in 2022 based on diffusion techniques. It is primarily used to generate detailed
+  images conditioned on text descriptions, though it can also be applied to other
+  tasks such as inpainting, outpainting, and generating image-to-image translations
+  guided by a text prompt.
+maintainer: stability.ai <auto-converted@casaos.io>
+name: icewhale-stable-diffusion-webui
+package_name: casaos-icewhale-stable-diffusion-webui-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/StableDiffusionWebUI/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/StableDiffusionWebUI/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/StableDiffusionWebUI/screenshot-3.webp
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/immich/config.yml
+++ b/sources/casaos-official/apps/immich/config.yml
@@ -1,0 +1,70 @@
+groups:
+- description: null
+  fields:
+  - default: immich
+    description: ''
+    id: DB_DATABASE_NAME
+    label: DB_DATABASE_NAME
+    required: false
+    type: string
+  - default: immich
+    description: ''
+    id: DB_DATABASE_NAME
+    label: DB_DATABASE_NAME
+    required: false
+    type: string
+  - default: immich
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: --data-checksums
+    description: ''
+    id: POSTGRES_INITDB_ARGS
+    label: POSTGRES_INITDB_ARGS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: postgres
+    description: ''
+    id: DB_PASSWORD
+    label: DB_PASSWORD
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: DB_USERNAME
+    label: DB_USERNAME
+    required: false
+    type: string
+  - default: postgres
+    description: ''
+    id: DB_PASSWORD
+    label: DB_PASSWORD
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: DB_USERNAME
+    label: DB_USERNAME
+    required: false
+    type: string
+  - default: postgres
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/immich/docker-compose.yml
+++ b/sources/casaos-official/apps/immich/docker-compose.yml
@@ -1,0 +1,61 @@
+name: immich
+services:
+  database:
+    command:
+    - postgres
+    - -c
+    - shared_preload_libraries=vectors.so
+    - -c
+    - search_path="$$user", public, vectors
+    - -c
+    - logging_collector=on
+    - -c
+    - max_wal_size=2GB
+    - -c
+    - shared_buffers=512MB
+    - -c
+    - wal_compression=on
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_INITDB_ARGS: ${POSTGRES_INITDB_ARGS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0@sha256:739cdd626151ff1f796dc95a6591b55a714f341c737e27f045019ceabf8e8c52
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/pgdata
+      target: /var/lib/postgresql/data
+      type: bind
+  immich-machine-learning:
+    environment:
+      DB_DATABASE_NAME: ${DB_DATABASE_NAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_USERNAME: ${DB_USERNAME}
+    image: altran1502/immich-machine-learning:v1.132.3
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/model-cache
+      target: /cache
+      type: bind
+  immich-server:
+    environment:
+      DB_DATABASE_NAME: ${DB_DATABASE_NAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_USERNAME: ${DB_USERNAME}
+    image: altran1502/immich-server:v1.132.3
+    ports:
+    - protocol: tcp
+      published: 2283
+      target: 2283
+    volumes:
+    - source: /Gallery/immich
+      target: /usr/src/app/upload
+      type: bind
+    - read_only: true
+      source: /etc/localtime
+      target: /etc/localtime
+      type: bind
+  redis:
+    image: docker.io/redis:6.2-alpine@sha256:148bb5411c184abd288d9aaed139c98123eeb8824c5d3fce03cf721db58066d8
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/redis
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/immich/metadata.yaml
+++ b/sources/casaos-official/apps/immich/metadata.yaml
@@ -1,0 +1,42 @@
+architecture: all
+debian_section: misc
+description: Self-hosted media management solution
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Immich/icon.png
+license: Unknown
+long_description: 'Immich: Revolutionizing Your Home Media Experience
+
+
+  Immich is here to transform the way you manage and enjoy your media files across
+  your home TV, smartphones, and other devices. Unlike traditional photo albums or
+  mainstream cloud services, immich offers a seamless and modern platform for organizing,
+  sharing, and accessing your photos and videos. Imagine effortlessly backing up your
+  precious moments from your mobile devices and viewing them instantly on your TV
+  or sharing them with family members—immich makes it all possible.
+
+
+  Immich stands out with its automatic backup from mobile devices, a sleek web-based
+  interface for easy media browsing, and advanced features like face recognition and
+  object detection. You can organize your media by location, enjoy 4K video playback,
+  and even manage RAW photos. Plus, with multi-user support, sharing memories with
+  friends and family is a breeze. The best part? Immich offers these powerful features
+  for low cost, ensuring you get a premium experience without breaking the bank.
+
+
+  Deploying immich on a private cloud device like Zima brings unparalleled convenience.
+  Enjoy unlimited storage capacity, blazing-fast local network speeds, and easy multi-device
+  access. With immich on your Zima private cloud, your media is always at your fingertips,
+  safe and secure in your home.
+
+  '
+maintainer: alextran1502 <auto-converted@casaos.io>
+name: immich
+package_name: casaos-immich-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Immich/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Immich/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Immich/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/jackett/config.yml
+++ b/sources/casaos-official/apps/jackett/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: 'true'
+    description: ''
+    id: AUTO_UPDATE
+    label: AUTO_UPDATE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/jackett/docker-compose.yml
+++ b/sources/casaos-official/apps/jackett/docker-compose.yml
@@ -1,0 +1,20 @@
+name: jackett
+services:
+  jackett:
+    environment:
+      AUTO_UPDATE: ${AUTO_UPDATE}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/jackett:0.22.1660
+    ports:
+    - protocol: tcp
+      published: 9117
+      target: 9117
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/jackett/metadata.yaml
+++ b/sources/casaos-official/apps/jackett/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: net
+description: Jackett works as a proxy server
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jackett/icon.png
+license: Unknown
+long_description: it translates queries from apps (Sonarr, Radarr, SickRage, CouchPotato,
+  Mylar3, Lidarr, DuckieTV, qBittorrent, Nefarious etc.) into tracker-site-specific
+  http queries, parses the html or json response, and then sends results back to the
+  requesting software. This allows for getting recent uploads (like RSS) and performing
+  searches. Jackett is a single repository of maintained indexer scraping & translation
+  logic - removing the burden from other apps.
+maintainer: Jackett <auto-converted@casaos.io>
+name: jackett
+package_name: casaos-jackett-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jackett/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jackett/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jackett/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/jdownloader2/config.yml
+++ b/sources/casaos-official/apps/jdownloader2/config.yml
@@ -1,0 +1,63 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: ID of the user the application runs as. See User/Group IDs to better
+      understand when this should be set.
+    id: USER_ID
+    label: USER_ID
+    required: false
+    type: string
+  - default: $PGID
+    description: ID of the group the application runs as. See User/Group IDs to better
+      understand when this should be set.
+    id: GROUP_ID
+    label: GROUP_ID
+    required: false
+    type: string
+  - default: $MYJDOWNLOADER_EMAIL
+    description: Email address of the MyJDownloader account to use. Note that this
+      can also be configured via the JDownloader GUI.
+    id: MYJDOWNLOADER_EMAIL
+    label: MYJDOWNLOADER_EMAIL
+    required: false
+    type: string
+  - default: $MYJDOWNLOADER_DEVICE_NAME
+    description: The name of this JDownloader instance. Note that this can also be
+      configured via the JDownloader GUI.
+    id: MYJDOWNLOADER_DEVICE_NAME
+    label: MYJDOWNLOADER_DEVICE_NAME
+    required: false
+    type: string
+  - default: $JDOWNLOADER_HEADLESS
+    description: When set to 1, JDownloader is running in headless mode, meaning that
+      no GUI is available. In this mode, MyJDownloader should be used to remote control
+      JDownloader.
+    id: JDOWNLOADER_HEADLESS
+    label: JDOWNLOADER_HEADLESS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: $MYJDOWNLOADER_PASSWORD
+    description: Password of the MyJDownloader account to use. Note that this can
+      also be configured via the JDownloader GUI.
+    id: MYJDOWNLOADER_PASSWORD
+    label: MYJDOWNLOADER_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/jdownloader2/docker-compose.yml
+++ b/sources/casaos-official/apps/jdownloader2/docker-compose.yml
@@ -1,0 +1,29 @@
+name: jdownloader2
+services:
+  jdownloader2:
+    environment:
+      GROUP_ID: ${GROUP_ID}
+      JDOWNLOADER_HEADLESS: ${JDOWNLOADER_HEADLESS}
+      MYJDOWNLOADER_DEVICE_NAME: ${MYJDOWNLOADER_DEVICE_NAME}
+      MYJDOWNLOADER_EMAIL: ${MYJDOWNLOADER_EMAIL}
+      MYJDOWNLOADER_PASSWORD: ${MYJDOWNLOADER_PASSWORD}
+      TZ: ${TZ}
+      USER_ID: ${USER_ID}
+    image: jlesage/jdownloader-2:latest
+    ports:
+    - protocol: tcp
+      published: 5800
+      target: 5800
+    - protocol: tcp
+      published: 5900
+      target: 5900
+    - protocol: tcp
+      published: 3129
+      target: 3129
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /output
+      type: bind

--- a/sources/casaos-official/apps/jdownloader2/metadata.yaml
+++ b/sources/casaos-official/apps/jdownloader2/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: utils
+description: Free & open-source download management tool
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/JDownloader2/icon.png
+license: Unknown
+long_description: JDownloader is a free, open-source download management tool with
+  a huge community that makes downloading as easy and fast as it should be. Users
+  can start, stop or pause downloads, set bandwith limitations, auto-extract archives
+  and much more. It's an easy-to-extend framework that can save hours of your valuable
+  time every day!
+maintainer: jdownloader <auto-converted@casaos.io>
+name: jdownloader2
+package_name: casaos-jdownloader2-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/JDownloader2/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/JDownloader2/screenshot-2.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/jellyfin-nvidia/config.yml
+++ b/sources/casaos-official/apps/jellyfin-nvidia/config.yml
@@ -1,0 +1,44 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Jellyfin as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Jellyfin as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: 'true'
+    description: ''
+    id: CPU_FALLBACK
+    label: CPU_FALLBACK
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: NVIDIA_VISIBLE_DEVICES
+    label: NVIDIA_VISIBLE_DEVICES
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/jellyfin-nvidia/docker-compose.yml
+++ b/sources/casaos-official/apps/jellyfin-nvidia/docker-compose.yml
@@ -1,0 +1,33 @@
+name: jellyfin-nvidia
+services:
+  jellyfin:
+    environment:
+      CPU_FALLBACK: ${CPU_FALLBACK}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/jellyfin:10.10.6
+    ports:
+    - protocol: tcp
+      published: 8097
+      target: 8096
+    - protocol: tcp
+      published: 8921
+      target: 8920
+    - protocol: tcp
+      published: 7359
+      target: 7359
+    - protocol: tcp
+      published: 1901
+      target: 1900
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media
+      target: /Media
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/opt/vc/lib
+      target: /opt/vc/lib
+      type: bind

--- a/sources/casaos-official/apps/jellyfin-nvidia/metadata.yaml
+++ b/sources/casaos-official/apps/jellyfin-nvidia/metadata.yaml
@@ -1,0 +1,32 @@
+architecture: all
+debian_section: video
+description: The personal Media System
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/icon.png
+license: Unknown
+long_description: 'Imagine having all your movies, TV shows, and music at your fingertips,
+  ready on any device. Jellyfin transforms your media collection into a personalized
+  entertainment hub, surpassing traditional photo albums. Your media is accessible
+  anywhere and beautifully organized.
+
+
+  Jellyfin is free and open-source, offering high-quality streaming, detailed metadata,
+  and personalized recommendations. Multiple users can have their own media libraries.
+
+
+  Deploying Jellyfin on private cloud devices like Zima provides virtually unlimited
+  storage, seamless streaming, and secure, multi-device access. It''s perfect for
+  NAS enthusiasts looking to enhance their home media setup.
+
+  '
+maintainer: Jellyfin <auto-converted@casaos.io>
+name: jellyfin-nvidia
+package_name: casaos-jellyfin-nvidia-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/jellyfin/config.yml
+++ b/sources/casaos-official/apps/jellyfin/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Jellyfin as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Jellyfin as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/jellyfin/docker-compose.yml
+++ b/sources/casaos-official/apps/jellyfin/docker-compose.yml
@@ -1,0 +1,31 @@
+name: jellyfin
+services:
+  jellyfin:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/jellyfin:10.10.7
+    ports:
+    - protocol: tcp
+      published: 8097
+      target: 8096
+    - protocol: tcp
+      published: 8921
+      target: 8920
+    - protocol: tcp
+      published: 7359
+      target: 7359
+    - protocol: tcp
+      published: 1901
+      target: 1900
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media
+      target: /Media
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/opt/vc/lib
+      target: /opt/vc/lib
+      type: bind

--- a/sources/casaos-official/apps/jellyfin/metadata.yaml
+++ b/sources/casaos-official/apps/jellyfin/metadata.yaml
@@ -1,0 +1,39 @@
+architecture: all
+debian_section: video
+description: The personal Media System
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/icon.png
+license: Unknown
+long_description: 'Jellyfin stands out among media server applications for its fully
+  open-source, free, and privacy-focused design. Unlike Emby and Plex, Jellyfin delivers
+  robust media management, real-time transcoding, and granular multi-user permissions
+  without subscription costs, operating independently of cloud services to ensure
+  full user control over data. Its community-driven development and efficient resource
+  usage enable smooth performance on low-end devices, making it the go-to choice for
+  privacy-conscious and budget-savvy users.
+
+
+  Picture your movies, TV shows, and music at your fingertips, accessible on any device.
+  Jellyfin transforms your media collection into a personalized entertainment hub,
+  surpassing traditional photo albums with a seamless browsing and playback experience.
+
+  Jellyfin offers high-quality streaming, automatic metadata fetching, and personalized
+  recommendations, all at no cost. It supports multiple users, each with their own
+  media library, catering to the diverse needs of families or teams.
+
+  Deploying Jellyfin on private cloud devices like Zima provides near-unlimited storage,
+  smooth streaming, and secure multi-device access. For NAS enthusiasts or anyone
+  looking to elevate their home media setup, Jellyfin is the perfect solution.
+
+  '
+maintainer: Jellyfin <auto-converted@casaos.io>
+name: jellyfin
+package_name: casaos-jellyfin-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Jellyfin/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/jenkins/config.yml
+++ b/sources/casaos-official/apps/jenkins/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/jenkins/docker-compose.yml
+++ b/sources/casaos-official/apps/jenkins/docker-compose.yml
@@ -1,0 +1,15 @@
+name: jenkins
+services:
+  jenkins:
+    image: jenkins/jenkins:lts-jdk17
+    ports:
+    - protocol: tcp
+      published: 8080
+      target: 8080
+    volumes:
+    - source: /AppData/Jenkins/data
+      target: /data
+      type: bind
+    - source: /var/lib/docker/volumes/b098c98b2c5dec792246dc33375853c05958ace7c144f4aa157326a6f6c0de4c/_data
+      target: /var/jenkins_home
+      type: bind

--- a/sources/casaos-official/apps/jenkins/metadata.yaml
+++ b/sources/casaos-official/apps/jenkins/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: net
+description: Jenkins Continuous Integration and Delivery server.
+homepage: null
+icon: https://icon.casaos.io/main/all/jenkins.png
+license: Unknown
+long_description: A server for creating pipelines for Jenkins continuous integration
+  and delivery.
+maintainer: bepp-boop <auto-converted@casaos.io>
+name: jenkins
+package_name: casaos-jenkins-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/kavita/config.yml
+++ b/sources/casaos-official/apps/kavita/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: Time Zone Synchronization
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/kavita/docker-compose.yml
+++ b/sources/casaos-official/apps/kavita/docker-compose.yml
@@ -1,0 +1,17 @@
+name: kavita
+services:
+  kavita:
+    environment:
+      TZ: ${TZ}
+    image: jvmilazz0/kavita:0.8.6
+    ports:
+    - protocol: tcp
+      published: 5150
+      target: 5000
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /kavita/config
+      type: bind
+    - source: /Media/Manga
+      target: /manga
+      type: bind

--- a/sources/casaos-official/apps/kavita/metadata.yaml
+++ b/sources/casaos-official/apps/kavita/metadata.yaml
@@ -1,0 +1,83 @@
+architecture: all
+debian_section: video
+description: Kavita is a free and open source web based Comic and Book Server.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Kavita/icon.png
+license: Unknown
+long_description: 'Kavita is a self-hosted digital library app designed for managing
+  and reading comics, light novels, and e-books (supporting CBZ, CBR, EPUB, PDF, and
+  more), offering a secure and convenient solution for personal reading collections.
+  Its responsive Web interface allows users to access content effortlessly via any
+  browser, with fullscreen reading and full localization support, ideal for comic
+  and e-book enthusiasts building personalized digital libraries.
+
+
+  The app''s core features include robust library management and an enhanced reading
+  experience. Users can organize content with collections, reading lists, and custom
+  tags, editing metadata to keep libraries neatly arranged. The built-in manga reader
+  supports dual-page mode, Webtoon scrolling, and image splitting, while the e-book
+  reader offers customizable fonts, spacing, and themes, with by-line progress syncing
+  across devices. The PDF reader provides light/dark modes and diverse settings. It
+  supports multi-user management, allowing custom permissions for sharing libraries
+  or restricting content access, perfect for family or team use. Bulk imports and
+  full-text search streamline large collection management.
+
+
+  It can be flexibly deployed on personal servers or NAS devices, with an active community
+  providing extensive documentation to enhance functionality. Folder monitoring automatically
+  detects file changes without manual scans, and sending content to Kindle or other
+  devices improves cross-device access. Whether creating a personal reading hub or
+  sharing media with others, the app''s intuitive interface and high customizability
+  deliver a modern management platform, meeting needs from casual reading to professional
+  collections.
+
+
+  **Key Features:**
+
+  - Serve up Manga/Webtoons/Comics (cbr, cbz, zip/rar/rar5, 7zip, raw images) and
+  Books (epub, pdf)
+
+  - First class responsive readers that work great on any device (phone, tablet, desktop)
+
+  - Customizable theming support: [Theme Repo](https://github.com/Kareadita/Themes)
+  and [Documentation](https://wiki.kavitareader.com/guides/themes/)
+
+  - External metadata integration and scrobbling for read status, ratings, and reviews
+  (available via Kavita+)
+
+  - Rich Metadata support with filtering and searching
+
+  - Ways to group reading material: Collections, Reading Lists (CBL Import), Want
+  to Read
+
+  - Ability to manage users with rich Role-based management for age restrictions,
+  abilities within the app, etc
+
+  - Rich web readers supporting webtoon, continuous reading mode (continue without
+  leaving the reader), virtual pages (epub), etc
+
+  - Ability to customize your dashboard and side nav with smart filters, custom order
+  and visibility toggles
+
+  - Ability to download metadata (available via Kavita+)
+
+
+  **Learn More:**
+
+  - [Kavita Official Website](https://www.kavitareader.com)
+
+  - [Kavita GitHub Repository](https://github.com/Kareadita/Kavita)
+
+  '
+maintainer: jvmilazz0 <auto-converted@casaos.io>
+name: kavita
+package_name: casaos-kavita-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Kavita/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Kavita/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Kavita/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Kavita/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/komga/config.yml
+++ b/sources/casaos-official/apps/komga/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/komga/docker-compose.yml
+++ b/sources/casaos-official/apps/komga/docker-compose.yml
@@ -1,0 +1,21 @@
+name: komga
+services:
+  komga:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+    image: gotson/komga:1.22.0
+    ports:
+    - protocol: tcp
+      published: 25600
+      target: 25600
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+    - source: /etc/timezone
+      target: /etc/timezone
+      type: bind

--- a/sources/casaos-official/apps/komga/metadata.yaml
+++ b/sources/casaos-official/apps/komga/metadata.yaml
@@ -1,0 +1,81 @@
+architecture: all
+debian_section: video
+description: Komga is a media server for your comics, mangas, BDs, magazines and eBooks.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Komga/icon.png
+license: Unknown
+long_description: 'Komga is a self-hosted app designed for managing comics, manga,
+  magazines, and e-books (supporting CBZ, CBR, PDF, and EPUB formats), offering a
+  secure and convenient solution for personal media libraries. Its responsive Web
+  interface enables users to access and manage content effortlessly via any browser,
+  without complex local installations, ideal for comic and e-book enthusiasts.
+
+
+  The app''s core features include versatile content organization and diverse reading
+  options. Users can arrange their library with collections and reading lists, edit
+  metadata for series or books, and keep content neatly organized. It integrates a
+  built-in Web reader, supports Mihon SDK extensions, or connects with third-party
+  OPDS readers, catering to varied reading preferences. Whether managing a personal
+  comic collection or sharing e-books with family, it supports multi-user access and
+  delivers a smooth browsing experience. Bulk import streamlines large media library
+  management, perfect for efficient content organization.
+
+
+  It can be flexibly deployed on personal servers or NAS devices, with an active community
+  providing support documentation, enabling users to extend functionality through
+  community resources. Whether building a personal digital library or a private media-sharing
+  hub, the app''s intuitive interface and high customizability offer a secure, modern
+  media management platform, meeting needs from casual reading to professional collections.
+
+
+  **Key Features:**
+
+  - Organize your library with collections and read lists
+
+  - Edit metadata for your series and books
+
+  - Import embedded metadata automatically
+
+  - Webreader with multiple reading modes
+
+  - Manage multiple users, with per-library access control, age restrictions, and
+  labels restrictions
+
+  - Offers a REST API, many community tools and scripts can interact with Komga
+
+  - OPDS v1 and v2 support
+
+  - Kobo Sync with your Kobo eReader
+
+  - KOReader Sync
+
+  - Download book files, whole series, or read lists
+
+  - Duplicate files detection
+
+  - Duplicate pages detection and removal
+
+  - Import books from outside your libraries directly into your series folder
+
+  - Import ComicRack cbl read lists
+
+
+  **Learn More:**
+
+  - [Komga Official Website](https://komga.org)
+
+  - [Komga GitHub Repository](https://github.com/gotson/komga)
+
+  '
+maintainer: gotson <auto-converted@casaos.io>
+name: komga
+package_name: casaos-komga-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Komga/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Komga/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Komga/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Komga/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/label-studio/config.yml
+++ b/sources/casaos-official/apps/label-studio/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: timezone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/label-studio/docker-compose.yml
+++ b/sources/casaos-official/apps/label-studio/docker-compose.yml
@@ -1,0 +1,16 @@
+name: label-studio
+services:
+  label-studio:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: heartexlabs/label-studio:1.8.1
+    ports:
+    - protocol: tcp
+      published: 3080
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /label-studio/data
+      type: bind

--- a/sources/casaos-official/apps/label-studio/metadata.yaml
+++ b/sources/casaos-official/apps/label-studio/metadata.yaml
@@ -1,0 +1,25 @@
+architecture: all
+debian_section: misc
+description: Label Studio is an open source data labeling tool.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LabelStudio/icon.png
+license: Unknown
+long_description: 'Label Studio is an open source data labeling tool. It lets you
+  label data types like audio, text, images, videos, and time series with a simple
+  and straightforward UI and export to various model formats. It can be used to prepare
+  raw data or improve existing training data to get more accurate ML models.
+
+
+  Label Studio is an open source data labeling tool. It lets you label data types
+  like audio, text, images, videos, and time series with a simple and straightforward
+  UI and export to various model formats. It can be used to prepare raw data or improve
+  existing training data to get more accurate ML models.'
+maintainer: Yidadaa <auto-converted@casaos.io>
+name: label-studio
+package_name: casaos-label-studio-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LabelStudio/screenshot-1.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/langflow/config.yml
+++ b/sources/casaos-official/apps/langflow/config.yml
@@ -1,0 +1,48 @@
+groups:
+- description: null
+  fields:
+  - default: postgresql://langflow:langflow@langflow-postgres:5432/langflow
+    description: PostgreSQL Database Connection URL
+    id: LANGFLOW_DATABASE_URL
+    label: LANGFLOW_DATABASE_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: /app/langflow
+    description: Directory for Langflow Configuration Files
+    id: LANGFLOW_CONFIG_DIR
+    label: LANGFLOW_CONFIG_DIR
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+- description: null
+  fields:
+  - default: langflow
+    description: PostgreSQL Username
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: langflow
+    description: PostgreSQL Password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: langflow
+    description: PostgreSQL Database Name
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/langflow/docker-compose.yml
+++ b/sources/casaos-official/apps/langflow/docker-compose.yml
@@ -1,0 +1,25 @@
+name: langflow
+services:
+  langflow:
+    environment:
+      LANGFLOW_CONFIG_DIR: ${LANGFLOW_CONFIG_DIR}
+      LANGFLOW_DATABASE_URL: ${LANGFLOW_DATABASE_URL}
+    image: langflowai/langflow:1.5.0
+    ports:
+    - protocol: tcp
+      published: 17860
+      target: 7860
+    volumes:
+    - source: /AppData/$AppID/backend
+      target: /app/langflow
+      type: bind
+  langflow-postgres:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: postgres:16
+    volumes:
+    - source: /AppData/$AppID/postgres
+      target: /var/lib/postgresql/data
+      type: bind

--- a/sources/casaos-official/apps/langflow/metadata.yaml
+++ b/sources/casaos-official/apps/langflow/metadata.yaml
@@ -1,0 +1,53 @@
+architecture: all
+debian_section: misc
+description: Open-source UI for building and debugging multi-agent and RAG applications
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LangFlow/icon.png
+license: Unknown
+long_description: 'Langflow is a powerful, open-source UI designed specifically for
+  building and debugging multi-agent and Retrieval-Augmented Generation (RAG) applications.
+  It provides a visual, drag-and-drop interface that simplifies the process of creating
+  complex AI workflows.
+
+
+  The system consists of two main components:
+
+  - **Langflow**: The main application providing a visual interface for building AI
+  workflows
+
+  - **PostgreSQL**: A robust database system for storing application data and configurations
+
+
+  **Key Features:**
+
+  - Visual, drag-and-drop interface for building AI workflows
+
+  - Support for multi-agent systems and RAG applications
+
+  - Integrated debugging tools for testing and optimization
+
+  - Persistent storage for workflows and configurations
+
+  - Easy deployment with Docker containers
+
+
+  **Learn More:**
+
+  - [Langflow Official Website](https://www.langflow.org)
+
+  - [Langflow GitHub Repository](https://github.com/langflow-ai/langflow)
+
+  - [Documentation](https://docs.langflow.org)
+
+  '
+maintainer: langflowai <auto-converted@casaos.io>
+name: langflow
+package_name: casaos-langflow-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LangFlow/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LangFlow/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LangFlow/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/lazylibrarian/config.yml
+++ b/sources/casaos-official/apps/lazylibrarian/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: linuxserver/calibre-web:calibre|linuxserver/mods:lazylibrarian-ffmpeg
+    description: ''
+    id: DOCKER_MODS
+    label: DOCKER_MODS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $PGID
+    description: Run LazyLibrarian as specified GID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run LazyLibrarian as specified UID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/lazylibrarian/docker-compose.yml
+++ b/sources/casaos-official/apps/lazylibrarian/docker-compose.yml
@@ -1,0 +1,23 @@
+name: lazylibrarian
+services:
+  lazylibrarian:
+    environment:
+      DOCKER_MODS: ${DOCKER_MODS}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/lazylibrarian:version-7ef0109b
+    ports:
+    - protocol: tcp
+      published: 5299
+      target: 5299
+    volumes:
+    - source: /Downloads
+      target: /downloads
+      type: bind
+    - source: /Media/Books
+      target: /books
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/lazylibrarian/metadata.yaml
+++ b/sources/casaos-official/apps/lazylibrarian/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: misc
+description: eBook Auto Downloader
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lazylibrarian/icon.png
+license: Unknown
+long_description: Lazylibrarian is a program to follow authors and grab metadata for
+  all your digital reading needs. It uses a combination of Goodreads Librarything
+  and optionally GoogleBooks as sources for author info and book info. This container
+  is based on the DobyTang fork.
+maintainer: Lazylibrarian Team <auto-converted@casaos.io>
+name: lazylibrarian
+package_name: casaos-lazylibrarian-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lazylibrarian/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lazylibrarian/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lazylibrarian/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/librechat/config.yml
+++ b/sources/casaos-official/apps/librechat/config.yml
@@ -1,0 +1,428 @@
+groups:
+- description: null
+  fields:
+  - default: user_provided
+    description: ''
+    id: ASSISTANTS_API_KEY
+    label: ASSISTANTS_API_KEY
+    required: false
+    type: password
+  - default: user_provided
+    description: ''
+    id: OPENAI_API_KEY
+    label: OPENAI_API_KEY
+    required: false
+    type: password
+  - default: user_provided
+    description: ''
+    id: GOOGLE_KEY
+    label: GOOGLE_KEY
+    required: false
+    type: password
+  - default: user_provided
+    description: ''
+    id: ANTHROPIC_API_KEY
+    label: ANTHROPIC_API_KEY
+    required: false
+    type: password
+  - default: 'false'
+    description: ''
+    id: LIMIT_MESSAGE_USER
+    label: LIMIT_MESSAGE_USER
+    required: false
+    type: string
+  - default: 16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef
+    description: JWT Secret Key for Authentication
+    id: JWT_SECRET
+    label: JWT_SECRET
+    required: false
+    type: password
+  - default: eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418
+    description: JWT Refresh Secret Key
+    id: JWT_REFRESH_SECRET
+    label: JWT_REFRESH_SECRET
+    required: false
+    type: password
+  - default: f34be427ebb29de8d88c107a71546019685ed8b241d8f2ed00c3df97ad2566f0
+    description: ''
+    id: CREDS_KEY
+    label: CREDS_KEY
+    required: false
+    type: password
+  - default: DrhYf7zENyR6AlUCKmnz0eYASOQdl6zxH7s7MKFSfFCt
+    description: MeiliSearch Master Key
+    id: MEILI_MASTER_KEY
+    label: MEILI_MASTER_KEY
+    required: false
+    type: password
+  - default: myuser
+    description: PostgreSQL Username
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: mypassword
+    description: PostgreSQL Password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: 0.0.0.0
+    description: Host Address
+    id: HOST
+    label: HOST
+    required: false
+    type: string
+  - default: '3080'
+    description: ''
+    id: PORT
+    label: PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: http://librechat-meilisearch:7700
+    description: MeiliSearch Host
+    id: MEILI_HOST
+    label: MEILI_HOST
+    required: false
+    type: string
+  - default: '8000'
+    description: RAG API Port
+    id: RAG_PORT
+    label: RAG_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: http://librechat-rag-api:8000
+    description: RAG API URL
+    id: RAG_API_URL
+    label: RAG_API_URL
+    required: false
+    type: string
+  - default: http://librechat-meilisearch:7700
+    description: MeiliSearch Host Address
+    id: MEILI_HOST
+    label: MEILI_HOST
+    required: false
+    type: string
+  - default: librechat-vectordb
+    description: Database Host for RAG
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '8000'
+    description: RAG Service Port
+    id: RAG_PORT
+    label: RAG_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: http://0.0.0.0:3080
+    description: ''
+    id: DOMAIN_CLIENT
+    label: DOMAIN_CLIENT
+    required: false
+    type: string
+  - default: http://0.0.0.0:3080
+    description: ''
+    id: DOMAIN_SERVER
+    label: DOMAIN_SERVER
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: NO_INDEX
+    label: NO_INDEX
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: TRUST_PROXY
+    label: TRUST_PROXY
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: CONSOLE_JSON
+    label: CONSOLE_JSON
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: DEBUG_LOGGING
+    label: DEBUG_LOGGING
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: DEBUG_CONSOLE
+    label: DEBUG_CONSOLE
+    required: false
+    type: string
+  - default: mongodb://librechat-mongodb:27017/LibreChat
+    description: MongoDB Connection URI
+    id: MONGO_URI
+    label: MONGO_URI
+    required: false
+    type: string
+  - default: 'true'
+    description: Enable Search Functionality
+    id: SEARCH
+    label: SEARCH
+    required: false
+    type: string
+  - default: 'true'
+    description: Disable MeiliSearch Analytics in API
+    id: MEILI_NO_ANALYTICS
+    label: MEILI_NO_ANALYTICS
+    required: false
+    type: string
+  - default: 'false'
+    description: Enable OpenAI Content Moderation
+    id: OPENAI_MODERATION
+    label: OPENAI_MODERATION
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: BAN_VIOLATIONS
+    label: BAN_VIOLATIONS
+    required: false
+    type: string
+  - default: 1000 * 60 * 60 * 2
+    description: ''
+    id: BAN_DURATION
+    label: BAN_DURATION
+    required: false
+    type: string
+  - default: '20'
+    description: ''
+    id: BAN_INTERVAL
+    label: BAN_INTERVAL
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: LOGIN_VIOLATION_SCORE
+    label: LOGIN_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: REGISTRATION_VIOLATION_SCORE
+    label: REGISTRATION_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: CONCURRENT_VIOLATION_SCORE
+    label: CONCURRENT_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: MESSAGE_VIOLATION_SCORE
+    label: MESSAGE_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '20'
+    description: ''
+    id: NON_BROWSER_VIOLATION_SCORE
+    label: NON_BROWSER_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: TTS_VIOLATION_SCORE
+    label: TTS_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: STT_VIOLATION_SCORE
+    label: STT_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: FORK_VIOLATION_SCORE
+    label: FORK_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: IMPORT_VIOLATION_SCORE
+    label: IMPORT_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '0'
+    description: ''
+    id: FILE_UPLOAD_VIOLATION_SCORE
+    label: FILE_UPLOAD_VIOLATION_SCORE
+    required: false
+    type: string
+  - default: '7'
+    description: ''
+    id: LOGIN_MAX
+    label: LOGIN_MAX
+    required: false
+    type: string
+  - default: '5'
+    description: ''
+    id: LOGIN_WINDOW
+    label: LOGIN_WINDOW
+    required: false
+    type: string
+  - default: '5'
+    description: ''
+    id: REGISTER_MAX
+    label: REGISTER_MAX
+    required: false
+    type: string
+  - default: '60'
+    description: ''
+    id: REGISTER_WINDOW
+    label: REGISTER_WINDOW
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: LIMIT_CONCURRENT_MESSAGES
+    label: LIMIT_CONCURRENT_MESSAGES
+    required: false
+    type: string
+  - default: '2'
+    description: ''
+    id: CONCURRENT_MESSAGE_MAX
+    label: CONCURRENT_MESSAGE_MAX
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: LIMIT_MESSAGE_IP
+    label: LIMIT_MESSAGE_IP
+    required: false
+    type: string
+  - default: '40'
+    description: ''
+    id: MESSAGE_IP_MAX
+    label: MESSAGE_IP_MAX
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: MESSAGE_IP_WINDOW
+    label: MESSAGE_IP_WINDOW
+    required: false
+    type: string
+  - default: '40'
+    description: ''
+    id: MESSAGE_USER_MAX
+    label: MESSAGE_USER_MAX
+    required: false
+    type: string
+  - default: '1'
+    description: ''
+    id: MESSAGE_USER_WINDOW
+    label: MESSAGE_USER_WINDOW
+    required: false
+    type: string
+  - default: '5'
+    description: ''
+    id: ILLEGAL_MODEL_REQ_SCORE
+    label: ILLEGAL_MODEL_REQ_SCORE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: ALLOW_EMAIL_LOGIN
+    label: ALLOW_EMAIL_LOGIN
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: ALLOW_REGISTRATION
+    label: ALLOW_REGISTRATION
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: ALLOW_SOCIAL_LOGIN
+    label: ALLOW_SOCIAL_LOGIN
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: ALLOW_SOCIAL_REGISTRATION
+    label: ALLOW_SOCIAL_REGISTRATION
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: ALLOW_PASSWORD_RESET
+    label: ALLOW_PASSWORD_RESET
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: ALLOW_UNVERIFIED_EMAIL_LOGIN
+    label: ALLOW_UNVERIFIED_EMAIL_LOGIN
+    required: false
+    type: string
+  - default: 1000 * 60 * 15
+    description: ''
+    id: SESSION_EXPIRY
+    label: SESSION_EXPIRY
+    required: false
+    type: string
+  - default: (1000 * 60 * 60 * 24) * 7
+    description: ''
+    id: REFRESH_TOKEN_EXPIRY
+    label: REFRESH_TOKEN_EXPIRY
+    required: false
+    type: string
+  - default: e2341419ec3dd3d19b13a1a87fafcbfb
+    description: ''
+    id: CREDS_IV
+    label: CREDS_IV
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: DEBUG_PLUGINS
+    label: DEBUG_PLUGINS
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: DEBUG_OPENAI
+    label: DEBUG_OPENAI
+    required: false
+    type: string
+  - default: 'true'
+    description: Disable MeiliSearch Analytics
+    id: MEILI_NO_ANALYTICS
+    label: MEILI_NO_ANALYTICS
+    required: false
+    type: string
+  - default: mydatabase
+    description: PostgreSQL Database Name
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/librechat/docker-compose.yml
+++ b/sources/casaos-official/apps/librechat/docker-compose.yml
@@ -1,0 +1,113 @@
+name: librechat
+services:
+  librechat-api:
+    environment:
+      ALLOW_EMAIL_LOGIN: ${ALLOW_EMAIL_LOGIN}
+      ALLOW_PASSWORD_RESET: ${ALLOW_PASSWORD_RESET}
+      ALLOW_REGISTRATION: ${ALLOW_REGISTRATION}
+      ALLOW_SOCIAL_LOGIN: ${ALLOW_SOCIAL_LOGIN}
+      ALLOW_SOCIAL_REGISTRATION: ${ALLOW_SOCIAL_REGISTRATION}
+      ALLOW_UNVERIFIED_EMAIL_LOGIN: ${ALLOW_UNVERIFIED_EMAIL_LOGIN}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      ASSISTANTS_API_KEY: ${ASSISTANTS_API_KEY}
+      BAN_DURATION: ${BAN_DURATION}
+      BAN_INTERVAL: ${BAN_INTERVAL}
+      BAN_VIOLATIONS: ${BAN_VIOLATIONS}
+      CONCURRENT_MESSAGE_MAX: ${CONCURRENT_MESSAGE_MAX}
+      CONCURRENT_VIOLATION_SCORE: ${CONCURRENT_VIOLATION_SCORE}
+      CONSOLE_JSON: ${CONSOLE_JSON}
+      CREDS_IV: ${CREDS_IV}
+      CREDS_KEY: ${CREDS_KEY}
+      DEBUG_CONSOLE: ${DEBUG_CONSOLE}
+      DEBUG_LOGGING: ${DEBUG_LOGGING}
+      DEBUG_OPENAI: ${DEBUG_OPENAI}
+      DEBUG_PLUGINS: ${DEBUG_PLUGINS}
+      DOMAIN_CLIENT: ${DOMAIN_CLIENT}
+      DOMAIN_SERVER: ${DOMAIN_SERVER}
+      FILE_UPLOAD_VIOLATION_SCORE: ${FILE_UPLOAD_VIOLATION_SCORE}
+      FORK_VIOLATION_SCORE: ${FORK_VIOLATION_SCORE}
+      GOOGLE_KEY: ${GOOGLE_KEY}
+      HOST: ${HOST}
+      ILLEGAL_MODEL_REQ_SCORE: ${ILLEGAL_MODEL_REQ_SCORE}
+      IMPORT_VIOLATION_SCORE: ${IMPORT_VIOLATION_SCORE}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
+      JWT_SECRET: ${JWT_SECRET}
+      LIMIT_CONCURRENT_MESSAGES: ${LIMIT_CONCURRENT_MESSAGES}
+      LIMIT_MESSAGE_IP: ${LIMIT_MESSAGE_IP}
+      LIMIT_MESSAGE_USER: ${LIMIT_MESSAGE_USER}
+      LOGIN_MAX: ${LOGIN_MAX}
+      LOGIN_VIOLATION_SCORE: ${LOGIN_VIOLATION_SCORE}
+      LOGIN_WINDOW: ${LOGIN_WINDOW}
+      MEILI_HOST: ${MEILI_HOST}
+      MEILI_NO_ANALYTICS: ${MEILI_NO_ANALYTICS}
+      MESSAGE_IP_MAX: ${MESSAGE_IP_MAX}
+      MESSAGE_IP_WINDOW: ${MESSAGE_IP_WINDOW}
+      MESSAGE_USER_MAX: ${MESSAGE_USER_MAX}
+      MESSAGE_USER_WINDOW: ${MESSAGE_USER_WINDOW}
+      MESSAGE_VIOLATION_SCORE: ${MESSAGE_VIOLATION_SCORE}
+      MONGO_URI: ${MONGO_URI}
+      NON_BROWSER_VIOLATION_SCORE: ${NON_BROWSER_VIOLATION_SCORE}
+      NO_INDEX: ${NO_INDEX}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_MODERATION: ${OPENAI_MODERATION}
+      PORT: ${PORT}
+      RAG_API_URL: ${RAG_API_URL}
+      RAG_PORT: ${RAG_PORT}
+      REFRESH_TOKEN_EXPIRY: ${REFRESH_TOKEN_EXPIRY}
+      REGISTER_MAX: ${REGISTER_MAX}
+      REGISTER_WINDOW: ${REGISTER_WINDOW}
+      REGISTRATION_VIOLATION_SCORE: ${REGISTRATION_VIOLATION_SCORE}
+      SEARCH: ${SEARCH}
+      SESSION_EXPIRY: ${SESSION_EXPIRY}
+      STT_VIOLATION_SCORE: ${STT_VIOLATION_SCORE}
+      TRUST_PROXY: ${TRUST_PROXY}
+      TTS_VIOLATION_SCORE: ${TTS_VIOLATION_SCORE}
+    image: ghcr.io/danny-avila/librechat-dev:latest
+    ports:
+    - protocol: tcp
+      published: 3080
+      target: 3080
+    volumes:
+    - source: /AppData/$AppID/images
+      target: /app/client/public/images
+      type: bind
+    - source: /AppData/$AppID/uploads
+      target: /app/uploads
+      type: bind
+    - source: /AppData/$AppID/logs
+      target: /app/api/logs
+      type: bind
+  librechat-meilisearch:
+    environment:
+      MEILI_HOST: ${MEILI_HOST}
+      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
+      MEILI_NO_ANALYTICS: ${MEILI_NO_ANALYTICS}
+    image: getmeili/meilisearch:v1.12.3
+    volumes:
+    - source: /AppData/$AppID/meili_data_v1.12
+      target: /meili_data
+      type: bind
+  librechat-mongodb:
+    command:
+    - mongod
+    - --noauth
+    image: mongo:6.0
+    volumes:
+    - source: /AppData/$AppID/data-node
+      target: /data/db
+      type: bind
+  librechat-rag-api:
+    environment:
+      DB_HOST: ${DB_HOST}
+      RAG_PORT: ${RAG_PORT}
+    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:v0.6.0
+  librechat-vectordb:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: ankane/pgvector:v0.5.1
+    volumes:
+    - source: /AppData/$AppID/postgresql/data
+      target: /var/lib/postgresql/data
+      type: bind

--- a/sources/casaos-official/apps/librechat/metadata.yaml
+++ b/sources/casaos-official/apps/librechat/metadata.yaml
@@ -1,0 +1,59 @@
+architecture: all
+debian_section: misc
+description: A full-featured, open-source AI chat interface
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LibreChat/icon.png
+license: Unknown
+long_description: 'LibreChat is a full-featured, open-source AI chat interface that
+  allows users to interact with multiple AI models through a unified platform. It
+  supports various AI providers and offers advanced features like conversation management,
+  plugin support, and customizable interfaces.
+
+  **Key Features:**
+
+  - Support for multiple AI models and providers
+
+  - Conversation history and management
+
+  - Plugin system for extended functionality
+
+  - Customizable themes and interfaces
+
+  - User authentication and management
+
+  - API integrations for various services
+
+  - Search functionality with MeiliSearch
+
+  - RAG (Retrieval-Augmented Generation) support
+
+  - File upload and processing capabilities
+
+  - Multi-language support
+
+  **Learn More:**
+
+  - [LibreChat Official Website](https://www.librechat.ai)
+
+  - [LibreChat GitHub Repository](https://github.com/danny-avila/LibreChat)
+
+
+  ** extra: **
+
+  You can refer to the [Custom AI Endpoints](https://www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints)
+  documentation to configure the relevant files for calling the APIs of Anyscale,
+  ApiPie, Cohere, Deepseek, Databricks, Fireworks, Groq, HuggingFace, Mistral, OpenRouter,
+  Perplexity, ShuttleAI, TogetherAI, Unify, and xAI.
+
+  '
+maintainer: LibreChat <auto-converted@casaos.io>
+name: librechat
+package_name: casaos-librechat-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LibreChat/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LibreChat/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LibreChat/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/lidarr/config.yml
+++ b/sources/casaos-official/apps/lidarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/lidarr/docker-compose.yml
+++ b/sources/casaos-official/apps/lidarr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: lidarr
+services:
+  lidarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/lidarr:2.9.6
+    ports:
+    - protocol: tcp
+      published: 8686
+      target: 8686
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Media/Music
+      target: /music
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/lidarr/metadata.yaml
+++ b/sources/casaos-official/apps/lidarr/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: misc
+description: Music collection manager for Usenet and BitTorrent users
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lidarr/icon.png
+license: Unknown
+long_description: Lidarr is a music collection manager for Usenet and BitTorrent users.
+  It can monitor multiple RSS feeds for new albums from your favorite artists and
+  will interface with clients and indexers to grab, sort, and rename them. It can
+  also be configured to automatically upgrade the quality of existing files in the
+  library when a better quality format becomes available.
+maintainer: lidarr Team <auto-converted@casaos.io>
+name: lidarr
+package_name: casaos-lidarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lidarr/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lidarr/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lidarr/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/llama-factory-nvidia/config.yml
+++ b/sources/casaos-official/apps/llama-factory-nvidia/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/llama-factory-nvidia/docker-compose.yml
+++ b/sources/casaos-official/apps/llama-factory-nvidia/docker-compose.yml
@@ -1,0 +1,11 @@
+name: llama-factory-nvidia
+services:
+  llama-factory-nvidia:
+    command:
+    - llamafactory-cli
+    - webui
+    image: hiyouga/llamafactory:0.9.4
+    ports:
+    - protocol: tcp
+      published: 18877
+      target: 7860

--- a/sources/casaos-official/apps/llama-factory-nvidia/metadata.yaml
+++ b/sources/casaos-official/apps/llama-factory-nvidia/metadata.yaml
@@ -1,0 +1,50 @@
+architecture: all
+debian_section: misc
+description: Einheitliche LLM-Feinabstimmung mit 100+ Modellen
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LLaMA-Factory_Nvidia/icon.png
+license: Unknown
+long_description: 'LLaMA Factory ist ein umfassendes Framework für das Fine-Tuning
+  von Large Language Models (LLMs) mit über 100 unterstützten Modellen. Es bietet
+  eine benutzerfreundliche Web-Oberfläche und leistungsstarke Trainingsmethoden wie
+  LoRA, QLoRA und Full-Parameter-Training.
+
+
+  **Hauptfunktionen:**
+
+  - Unterstützung für 100+ LLMs einschließlich LLaMA, Mistral, Qwen und mehr
+
+  - Mehrere Fine-Tuning-Methoden (LoRA, QLoRA, Full, Freeze)
+
+  - Intuitive Web-UI für einfache Modellverwaltung
+
+  - Integrierter API-Server für Modellinferenz
+
+  - Multi-GPU-Training-Unterstützung
+
+  - Quantisierung und Modellexport
+
+
+  **Hardwareanforderungen:**
+
+  - GPU: NVIDIA GPU mit CUDA-Unterstützung erforderlich
+
+
+  **Weitere Informationen:**
+
+  - [GitHub Repository](https://github.com/hiyouga/LLaMA-Factory)
+
+  - [Dokumentation](https://llamafactory.readthedocs.io/)
+
+  '
+maintainer: hiyouga <auto-converted@casaos.io>
+name: llama-factory-nvidia
+package_name: casaos-llama-factory-nvidia-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LLaMA-Factory_Nvidia/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LLaMA-Factory_Nvidia/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LLaMA-Factory_Nvidia/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/lucky/config.yml
+++ b/sources/casaos-official/apps/lucky/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/lucky/docker-compose.yml
+++ b/sources/casaos-official/apps/lucky/docker-compose.yml
@@ -1,0 +1,10 @@
+name: lucky
+services:
+  lucky:
+    environment:
+      TZ: ${TZ}
+    image: gdy666/lucky:2.15.7
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}
+      target: /goodluck
+      type: bind

--- a/sources/casaos-official/apps/lucky/metadata.yaml
+++ b/sources/casaos-official/apps/lucky/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: net
+description: Powerful networking tool
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lucky/icon.png
+license: Unknown
+long_description: A powerful tool for port forwarding, reverse proxy, dynamic DNS,
+  wake-on-LAN, IPv4 NAT traversal, webdav services, task scheduling, and automatic
+  certificate management.
+maintainer: gdy666 <auto-converted@casaos.io>
+name: lucky
+package_name: casaos-lucky-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lucky/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lucky/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Lucky/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/lyrionmusicserver/config.yml
+++ b/sources/casaos-official/apps/lyrionmusicserver/config.yml
@@ -1,0 +1,14 @@
+groups:
+- description: null
+  fields:
+  - default: '9000'
+    description: HTTP Port for Web Interface
+    id: HTTP_PORT
+    label: HTTP_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/lyrionmusicserver/docker-compose.yml
+++ b/sources/casaos-official/apps/lyrionmusicserver/docker-compose.yml
@@ -1,0 +1,38 @@
+name: lyrionmusicserver
+services:
+  lyrionmusicserver:
+    environment:
+      HTTP_PORT: ${HTTP_PORT}
+    image: lmscommunity/lyrionmusicserver:9.1.0
+    ports:
+    - protocol: tcp
+      published: 9000
+      target: 9000
+    - protocol: tcp
+      published: 9090
+      target: 9090
+    - protocol: tcp
+      published: 3483
+      target: 3483
+    - protocol: udp
+      published: 3483
+      target: 3483
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - read_only: true
+      source: /Media/Music
+      target: /music
+      type: bind
+    - source: /AppData/$AppID/playlists
+      target: /playlist
+      type: bind
+    - read_only: true
+      source: /etc/localtime
+      target: /etc/localtime
+      type: bind
+    - read_only: true
+      source: /etc/timezone
+      target: /etc/timezone
+      type: bind

--- a/sources/casaos-official/apps/lyrionmusicserver/metadata.yaml
+++ b/sources/casaos-official/apps/lyrionmusicserver/metadata.yaml
@@ -1,0 +1,64 @@
+architecture: all
+debian_section: video
+description: Lyrion Music Server is a streaming audio server for Squeezebox audio
+  players.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LyrionMusicServer/icon.png
+license: Unknown
+long_description: 'Lyrion Music Server is a self-hosted music management app designed
+  to control a variety of audio playback devices, supporting streaming of local music
+  collections, internet radio, and multiple streaming services (with or without subscriptions).
+  Its intuitive Web interface enables users to access and control music effortlessly
+  via any browser, ideal for music enthusiasts creating personalized audio experiences.
+
+
+  The app''s core features include versatile music streaming and extensive customization.
+  Users can seamlessly play local music libraries, listen to global internet radio,
+  or connect to streaming services, catering to diverse listening needs. It offers
+  flexible control options, allowing customization of server functionality, interaction
+  methods, and interface appearance. Additionally, it supports a unified interface
+  across multiple devices, ensuring a consistent experience on phones, computers,
+  or other players, with the ability to select the ideal playback device for any scenario.
+
+
+  It can be flexibly deployed on personal servers or NAS devices, with community-provided
+  documentation aiding users in optimising setups and extending functionality. Whether
+  managing personal music collections or creating a shared audio hub for family, the
+  app''s intuitive operation and high flexibility deliver a modern music management
+  platform, meeting needs from casual listening to professional audio management.
+
+
+  **Key Features:**
+
+  - Music streaming for local collections, internet radio, and multiple streaming
+  services
+
+  - Intuitive Web interface for effortless music access and control via any browser
+
+  - Extensive customisation options for server functionality, interaction methods,
+  and interface appearance
+
+  - Unified multi-device interface ensuring consistent experience across phones, computers,
+  and other players
+
+  - Community documentation support for optimising setups and extending functionality
+
+
+  **Learn More:**
+
+  - [Lyrion Music Server Official Website](https://www.lyrion.org)
+
+  - [Lyrion Music Server GitHub Repository](https://github.com/lms-community/slimserver)
+
+  '
+maintainer: LMS-Community <auto-converted@casaos.io>
+name: lyrionmusicserver
+package_name: casaos-lyrionmusicserver-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LyrionMusicServer/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LyrionMusicServer/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/LyrionMusicServer/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/mariadb/config.yml
+++ b/sources/casaos-official/apps/mariadb/config.yml
@@ -1,0 +1,70 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: specify a timezone to use, see this list.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: Set this to root password for installation (minimum 4 characters
+      & non-alphanumeric passwords must be properly escaped).
+    id: MYSQL_ROOT_PASSWORD
+    label: MYSQL_ROOT_PASSWORD
+    required: false
+    type: password
+  - default: casaos
+    description: This user will have superuser access to the database specified by
+      MYSQL_DATABASE (do not use root here).
+    id: MYSQL_USER
+    label: MYSQL_USER
+    required: false
+    type: string
+  - default: casaos
+    description: Set this to the password you want to use for you MYSQL_USER (minimum
+      4 characters & non-alphanumeric passwords must be properly escaped).
+    id: MYSQL_PASSWORD
+    label: MYSQL_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: casaos
+    description: Specify the name of a database to be created on image startup.
+    id: MYSQL_DATABASE
+    label: MYSQL_DATABASE
+    required: false
+    type: string
+  - default: ''
+    description: Set this to ingest sql files from an http/https endpoint (comma seperated
+      array).
+    id: REMOTE_SQL
+    label: REMOTE_SQL
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/mariadb/docker-compose.yml
+++ b/sources/casaos-official/apps/mariadb/docker-compose.yml
@@ -1,0 +1,21 @@
+name: mariadb
+services:
+  mariadb:
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      REMOTE_SQL: ${REMOTE_SQL}
+      TZ: ${TZ}
+    image: linuxserver/mariadb:11.4.5
+    ports:
+    - protocol: tcp
+      published: 3306
+      target: 3306
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/mariadb/metadata.yaml
+++ b/sources/casaos-official/apps/mariadb/metadata.yaml
@@ -1,0 +1,31 @@
+architecture: all
+debian_section: devel
+description: MariaDB Server is one of the most popular database servers in the world.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MariaDB/icon.png
+license: Unknown
+long_description: 'MariaDB Server is one of the most popular database servers in the
+  world. It''s made by the original developers of MySQL and guaranteed to stay open
+  source.
+
+
+  MariaDB Server is one of the most popular open source relational databases. It’s
+  made by the original developers of MySQL and guaranteed to stay open source. It
+  is part of most cloud offerings and the default in most Linux distributions.
+
+
+  It is built upon the values of performance, stability, and openness, and MariaDB
+  Foundation ensures contributions will be accepted on technical merit. Recent new
+  functionality includes advanced clustering with Galera Cluster 4, compatibility
+  features with Oracle Database and Temporal Data Tables, allowing one to query the
+  data as it stood at any point in the past.
+
+  '
+maintainer: MariaDB Foundation <auto-converted@casaos.io>
+name: mariadb
+package_name: casaos-mariadb-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/maybe/config.yml
+++ b/sources/casaos-official/apps/maybe/config.yml
@@ -1,0 +1,168 @@
+groups:
+- description: null
+  fields:
+  - default: maybe_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: maybe_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: ${OPENAI_ACCESS_TOKEN}
+    description: ''
+    id: OPENAI_ACCESS_TOKEN
+    label: OPENAI_ACCESS_TOKEN
+    required: false
+    type: password
+  - default: maybe_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: maybe_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: ${OPENAI_ACCESS_TOKEN}
+    description: ''
+    id: OPENAI_ACCESS_TOKEN
+    label: OPENAI_ACCESS_TOKEN
+    required: false
+    type: password
+  - default: maybe_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: maybe_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: maybe_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: a7523c3d0ae56415046ad8abae168d71074a79534a7062258f8d1d51ac2f76d3c3bc86d86b6b0b307df30d9a6a90a2066a3fa9e67c5e6f374dbd7dd4e0778e13
+    description: ''
+    id: SECRET_KEY_BASE
+    label: SECRET_KEY_BASE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: SELF_HOSTED
+    label: SELF_HOSTED
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_FORCE_SSL
+    label: RAILS_FORCE_SSL
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_ASSUME_SSL
+    label: RAILS_ASSUME_SSL
+    required: false
+    type: string
+  - default: maybe_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: a7523c3d0ae56415046ad8abae168d71074a79534a7062258f8d1d51ac2f76d3c3bc86d86b6b0b307df30d9a6a90a2066a3fa9e67c5e6f374dbd7dd4e0778e13
+    description: ''
+    id: SECRET_KEY_BASE
+    label: SECRET_KEY_BASE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: SELF_HOSTED
+    label: SELF_HOSTED
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_FORCE_SSL
+    label: RAILS_FORCE_SSL
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_ASSUME_SSL
+    label: RAILS_ASSUME_SSL
+    required: false
+    type: string
+  - default: maybe_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: maybe-db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://maybe-redis:6379/1
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  - default: maybe-db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://maybe-redis:6379/1
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/maybe/docker-compose.yml
+++ b/sources/casaos-official/apps/maybe/docker-compose.yml
@@ -1,0 +1,58 @@
+name: maybe
+services:
+  maybe-db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: postgres:16
+    volumes:
+    - source: /AppData/$AppID/pgdata
+      target: /var/lib/postgresql/data
+      type: bind
+  maybe-redis:
+    image: redis:8.2.1-alpine3.22
+    volumes:
+    - source: /AppData/$AppID/redis/data
+      target: /data
+      type: bind
+  maybe-web:
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      RAILS_ASSUME_SSL: ${RAILS_ASSUME_SSL}
+      RAILS_FORCE_SSL: ${RAILS_FORCE_SSL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      SELF_HOSTED: ${SELF_HOSTED}
+    image: ghcr.io/maybe-finance/maybe:latest
+    ports:
+    - protocol: tcp
+      published: 23000
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/app/storage
+      target: /rails/storage
+      type: bind
+  maybe-worker:
+    command:
+    - bundle
+    - exec
+    - sidekiq
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      RAILS_ASSUME_SSL: ${RAILS_ASSUME_SSL}
+      RAILS_FORCE_SSL: ${RAILS_FORCE_SSL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      SELF_HOSTED: ${SELF_HOSTED}
+    image: ghcr.io/maybe-finance/maybe:latest

--- a/sources/casaos-official/apps/maybe/metadata.yaml
+++ b/sources/casaos-official/apps/maybe/metadata.yaml
@@ -1,0 +1,57 @@
+architecture: all
+debian_section: misc
+description: Personal finance management application
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Maybe/icon.png
+license: Unknown
+long_description: 'Maybe is a personal finance management application designed to
+  help you track your expenses, income, and investments in one place. With an intuitive
+  interface and powerful features, Maybe makes it easy to understand your financial
+  situation and make informed decisions about your money.
+
+
+  **Key Features:**
+
+  - **Expense Tracking**: Easily log and categorize your expenses
+
+  - **Income Management**: Track multiple income sources
+
+  - **Investment Monitoring**: Keep an eye on your investments and their performance
+
+  - **Budget Planning**: Create and maintain budgets to control your spending
+
+  - **Financial Reports**: Generate detailed reports to understand your financial
+  habits
+
+  - **AI-Powered Insights**: Get personalized financial advice using AI technology
+
+
+  **Use Cases:**
+
+  - Personal budget management
+
+  - Expense tracking and categorization
+
+  - Investment portfolio monitoring
+
+  - Financial goal setting and tracking
+
+  - Cash flow analysis
+
+
+  **Learn More:**
+
+  - [Maybe GitHub Repository](https://github.com/maybe-finance/maybe)
+
+  '
+maintainer: maybe-finance <auto-converted@casaos.io>
+name: maybe
+package_name: casaos-maybe-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Maybe/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Maybe/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Maybe/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/medusa/config.yml
+++ b/sources/casaos-official/apps/medusa/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: ' $TZ'
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/medusa/docker-compose.yml
+++ b/sources/casaos-official/apps/medusa/docker-compose.yml
@@ -1,0 +1,20 @@
+name: medusa
+services:
+  medusa:
+    environment:
+      TZ: ${TZ}
+    image: pymedusa/medusa:master
+    ports:
+    - protocol: tcp
+      published: 8081
+      target: 8081
+    volumes:
+    - source: /AppData/$AppID
+      target: /config
+      type: bind
+    - source: /AppData/$AppID/Downloads/Television
+      target: /downloads
+      type: bind
+    - source: /AppData/$AppID/Media/Television
+      target: /tv
+      type: bind

--- a/sources/casaos-official/apps/medusa/metadata.yaml
+++ b/sources/casaos-official/apps/medusa/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: video
+description: CasaOS Container App for medusa
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/icon.png
+license: Unknown
+long_description: Automatic Video Library Manager for TV Shows. It watches for new
+  episodes of your favorite shows, and when they are posted it does its magic.
+maintainer: pyMedusa (https://github.com/pymedusa) <auto-converted@casaos.io>
+name: medusa
+package_name: casaos-medusa-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Medusa/screenshot-6.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/memos/config.yml
+++ b/sources/casaos-official/apps/memos/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: timezone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/memos/docker-compose.yml
+++ b/sources/casaos-official/apps/memos/docker-compose.yml
@@ -1,0 +1,16 @@
+name: memos
+services:
+  memos:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: neosmemo/memos:0.24
+    ports:
+    - protocol: tcp
+      published: 5230
+      target: 5230
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/memos
+      target: /var/opt/memos
+      type: bind

--- a/sources/casaos-official/apps/memos/metadata.yaml
+++ b/sources/casaos-official/apps/memos/metadata.yaml
@@ -1,0 +1,40 @@
+architecture: all
+debian_section: text
+description: Memos is a lightweight, self-hosted memo hub. Open Source and Free forever.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/icon.png
+license: Unknown
+long_description: 'Memos is a lightweight, open-source, self-hosted note-taking application
+  that offers a secure and streamlined solution for users prioritizing privacy and
+  data control. All notes are stored on the user’s own server, eliminating risks associated
+  with third-party cloud services. Its minimalist Web interface supports Markdown
+  syntax and tag-based organization, enabling effortless capture of ideas, personal
+  knowledge management, or small-scale team collaboration. The open-source design
+  ensures transparency, long-term maintainability, and no subscription costs, making
+  it ideal for users seeking data ownership and cost efficiency.
+
+
+  Designed for simplicity and efficiency, Memos caters to a variety of use cases.
+  Whether jotting down daily thoughts, organizing study notes, or sharing task memos
+  in small teams, Memos delivers a seamless experience through its intuitive tag system
+  and Markdown formatting. Accessible via any web browser, it requires no proprietary
+  clients or complex setup, allowing users to manage notes anytime, anywhere.
+
+
+  Whether used for long-term personal knowledge archiving or as a lightweight tool
+  for team collaboration, Memos offers a secure, flexible, and user-friendly solution,
+  empowering users to maintain full control over their data while enjoying a streamlined
+  note-taking experience.
+
+  '
+maintainer: usememos Team <auto-converted@casaos.io>
+name: memos
+package_name: casaos-memos-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/mineos-node/config.yml
+++ b/sources/casaos-official/apps/mineos-node/config.yml
@@ -1,0 +1,54 @@
+groups:
+- description: null
+  fields:
+  - default: 'true'
+    description: Should the web interface use HTTPS or HTTP? Valid entries are "true"
+      and "false" (with quotes)
+    id: USE_HTTPS
+    label: USE_HTTPS
+    required: false
+    type: string
+  - default: mc
+    description: On startup, mineos will check if an account of the name "mc" exists.
+      If it does not exist, one will be created. This account, and any other created
+      with this variable will be permitted to login to the web interface.
+    id: USER_NAME
+    label: USER_NAME
+    required: false
+    type: string
+  - default: '1000'
+    description: If the "mc" account does not already exist, when mineos creates it,
+      it will do so with UID same as the value of the variable. If an account with
+      this UID already exists, account creation will be aborted.
+    id: USER_UID
+    label: USER_UID
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: '8443'
+    description: What port should the web interface listen on? This is independent
+      of the USE_HTTPS setting.
+    id: SERVER_PORT
+    label: SERVER_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: root
+    description: If the "mc" account is being created, it will use the default password
+      "root" (without quotes). It is recommended to change this to something more
+      secure.
+    id: USER_PASSWORD
+    label: USER_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/mineos-node/docker-compose.yml
+++ b/sources/casaos-official/apps/mineos-node/docker-compose.yml
@@ -1,0 +1,18 @@
+name: mineos-node
+services:
+  mineos:
+    environment:
+      SERVER_PORT: ${SERVER_PORT}
+      USER_NAME: ${USER_NAME}
+      USER_PASSWORD: ${USER_PASSWORD}
+      USER_UID: ${USER_UID}
+      USE_HTTPS: ${USE_HTTPS}
+    image: hexparrot/mineos:latest
+    ports:
+    - protocol: tcp
+      published: 8444
+      target: 8443
+    volumes:
+    - source: /var/games/mineos/minecraft
+      target: /var/games/minecraft
+      type: bind

--- a/sources/casaos-official/apps/mineos-node/metadata.yaml
+++ b/sources/casaos-official/apps/mineos-node/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: games
+description: Free and easy to use Minecraft server management tool.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MineOS/icon.png
+license: Unknown
+long_description: MineOS is a server front-end to ease managing Minecraft administrative
+  tasks. This iteration using Node.js aims to enhance previous MineOS scripts (Python-based),
+  by leveraging the event-triggering, asyncronous model of Node.JS and websockets.
+maintainer: hexparrot <auto-converted@casaos.io>
+name: mineos-node
+package_name: casaos-mineos-node-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/mongodb/config.yml
+++ b/sources/casaos-official/apps/mongodb/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: Specify a timezone to use.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/mongodb/docker-compose.yml
+++ b/sources/casaos-official/apps/mongodb/docker-compose.yml
@@ -1,0 +1,19 @@
+name: mongodb
+services:
+  mongo:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: mongo:8.0.5
+    ports:
+    - protocol: tcp
+      published: 27017
+      target: 27017
+    volumes:
+    - source: /AppData/mongo/data/configdb
+      target: /data/configdb
+      type: bind
+    - source: /AppData/mongo/data/db
+      target: /data/db
+      type: bind

--- a/sources/casaos-official/apps/mongodb/metadata.yaml
+++ b/sources/casaos-official/apps/mongodb/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: devel
+description: A free and open-source cross-platform document-oriented database program.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mongo/icon.png
+license: Unknown
+long_description: 'A free and open-source cross-platform document-oriented database
+  program. Classified as a NoSQL database program, MongoDB uses JSON-like documents
+  with schemata.
+
+
+  MongoDB is a free and open-source cross-platform document-oriented database program.
+  Classified as a NoSQL database program, MongoDB uses JSON-like documents with schemata.
+  MongoDB is developed by MongoDB Inc., and is published under a combination of the
+  Server Side Public License and the Apache License.'
+maintainer: MongoDB Inc. <auto-converted@casaos.io>
+name: mongodb
+package_name: casaos-mongodb-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/mongodb4/config.yml
+++ b/sources/casaos-official/apps/mongodb4/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: Specify a timezone to use.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/mongodb4/docker-compose.yml
+++ b/sources/casaos-official/apps/mongodb4/docker-compose.yml
@@ -1,0 +1,19 @@
+name: mongodb4
+services:
+  mongodb4:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: mongo:4.4.22
+    ports:
+    - protocol: tcp
+      published: 27017
+      target: 27017
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/data/configdb
+      target: /data/configdb
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/data/db
+      target: /data/db
+      type: bind

--- a/sources/casaos-official/apps/mongodb4/metadata.yaml
+++ b/sources/casaos-official/apps/mongodb4/metadata.yaml
@@ -1,0 +1,23 @@
+architecture: all
+debian_section: devel
+description: A free and open-source cross-platform document-oriented database program.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MongoDB4/icon.png
+license: Unknown
+long_description: 'A free and open-source cross-platform document-oriented database
+  program. Classified as a NoSQL database program, MongoDB uses JSON-like documents
+  with schemata.
+
+
+  MongoDB is a free and open-source cross-platform document-oriented database program.
+  Classified as a NoSQL database program, MongoDB uses JSON-like documents with schemata.
+  MongoDB is developed by MongoDB Inc., and is published under a combination of the
+  Server Side Public License and the Apache License.'
+maintainer: MongoDB Inc. <auto-converted@casaos.io>
+name: mongodb4
+package_name: casaos-mongodb4-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/monica/config.yml
+++ b/sources/casaos-official/apps/monica/config.yml
@@ -1,0 +1,62 @@
+groups:
+- description: null
+  fields:
+  - default: ChangeMeBy32KeyLengthOrGenerated
+    description: Application Encryption Key
+    id: APP_KEY
+    label: APP_KEY
+    required: false
+    type: password
+  - default: monicauser
+    description: Database Username
+    id: DB_USERNAME
+    label: DB_USERNAME
+    required: false
+    type: string
+  - default: monicasecret
+    description: Database Password
+    id: DB_PASSWORD
+    label: DB_PASSWORD
+    required: false
+    type: password
+  - default: 'True'
+    description: Generate Random Root Password
+    id: MARIADB_RANDOM_ROOT_PASSWORD
+    label: MARIADB_RANDOM_ROOT_PASSWORD
+    required: false
+    type: password
+  - default: monicauser
+    description: Database User
+    id: MARIADB_USER
+    label: MARIADB_USER
+    required: false
+    type: string
+  - default: monicasecret
+    description: Database Password
+    id: MARIADB_PASSWORD
+    label: MARIADB_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: monica-db
+    description: Database Host
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: monica
+    description: Database Name
+    id: MARIADB_DATABASE
+    label: MARIADB_DATABASE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/monica/docker-compose.yml
+++ b/sources/casaos-official/apps/monica/docker-compose.yml
@@ -1,0 +1,28 @@
+name: monica
+services:
+  monica:
+    environment:
+      APP_KEY: ${APP_KEY}
+      DB_HOST: ${DB_HOST}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_USERNAME: ${DB_USERNAME}
+    image: monica:4.1.2
+    ports:
+    - protocol: tcp
+      published: 18930
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/storage
+      target: /var/www/html/storage
+      type: bind
+  monica-db:
+    environment:
+      MARIADB_DATABASE: ${MARIADB_DATABASE}
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
+      MARIADB_RANDOM_ROOT_PASSWORD: ${MARIADB_RANDOM_ROOT_PASSWORD}
+      MARIADB_USER: ${MARIADB_USER}
+    image: mariadb:11.8.2
+    volumes:
+    - source: /AppData/$AppID/mysql
+      target: /var/lib/mysql
+      type: bind

--- a/sources/casaos-official/apps/monica/metadata.yaml
+++ b/sources/casaos-official/apps/monica/metadata.yaml
@@ -1,0 +1,65 @@
+architecture: all
+debian_section: utils
+description: A Personal Relationship Management tool to help you document your social
+  life.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Monica/icon.png
+license: Unknown
+long_description: 'Monica is a self-hosted personal relationship management tool that
+  helps users document and organize interactions with family and friends via an intuitive
+  Web interface, creating a personalized contact database. It is ideal for users balancing
+  work and life, ensuring key personal connections are never missed.
+
+
+  The tool''s core features include comprehensive contact management and smart reminders.
+  It supports creating detailed contact profiles, logging personal details, relationships
+  (e.g., family, friends), and how contacts were met. Users can set automatic reminders
+  for birthdays, anniversaries, and other key dates, while tracking conversations,
+  activities, and gift ideas. A diary feature records daily moods and significant
+  moments, maintaining a clear life record.
+
+
+  It offers task and debt management to track to-dos or financial interactions. Users
+  can upload photos and documents, favorite contacts, and organize relationships with
+  labels for streamlined data management. Full control over local data ensures privacy.
+  The tool’s intuitive operation and high flexibility deliver a modern relationship
+  management solution.
+
+
+  **Key Features:**
+
+  - Comprehensive contact management with detailed profiles
+
+  - Automatic reminders for birthdays, anniversaries, and key dates
+
+  - Track conversations, activities, and gift ideas
+
+  - Diary feature to record daily moods and moments
+
+  - Task and debt management for to-dos and finances
+
+  - Upload photos and documents, favorite contacts
+
+  - Organize contacts with labels
+
+  - Local data storage for privacy assurance
+
+
+  **Learn More:**
+
+  - [Monica Official Website](https://www.monicahq.com)
+
+  - [Monica GitHub Repository](https://github.com/monicahq/monica)
+
+  '
+maintainer: monica <auto-converted@casaos.io>
+name: monica
+package_name: casaos-monica-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Monica/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Monica/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Monica/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/motioneye/config.yml
+++ b/sources/casaos-official/apps/motioneye/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/motioneye/docker-compose.yml
+++ b/sources/casaos-official/apps/motioneye/docker-compose.yml
@@ -1,0 +1,15 @@
+name: motioneye
+services:
+  motioneye:
+    image: ccrisan/motioneye:master-amd64
+    ports:
+    - protocol: tcp
+      published: 8765
+      target: 8765
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /etc/motioneye
+      type: bind
+    - source: /Media/motioneye
+      target: /var/lib/motioneye
+      type: bind

--- a/sources/casaos-official/apps/motioneye/metadata.yaml
+++ b/sources/casaos-official/apps/motioneye/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: utils
+description: A web frontend for the motion daemon.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Motioneye/icon.png
+license: Unknown
+long_description: motionEye is a web-based frontend for motion. Check out the wiki
+  for more details. Changelog is available on the releases page. https://github.com/motioneye-project/motioneye
+maintainer: Motioneye <auto-converted@casaos.io>
+name: motioneye
+package_name: casaos-motioneye-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Motioneye/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Motioneye/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Motioneye/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/mylar3/config.yml
+++ b/sources/casaos-official/apps/mylar3/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Mylar3 as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Mylar3 as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/mylar3/docker-compose.yml
+++ b/sources/casaos-official/apps/mylar3/docker-compose.yml
@@ -1,0 +1,22 @@
+name: mylar3
+services:
+  mylar3:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/mylar3:0.8.2
+    ports:
+    - protocol: tcp
+      published: 8090
+      target: 8090
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Media/Comics
+      target: /comics
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/mylar3/metadata.yaml
+++ b/sources/casaos-official/apps/mylar3/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: misc
+description: Automatic comic book (cbr/cbz) downloader
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mylar3/icon.png
+license: Unknown
+long_description: Mylar is an automated Comic Book (cbr/cbz) downloader program for
+  use with NZB and torrents. Mylar allows you to create a watchlist of series that
+  it monitors for various things (new issues, updated information, etc). It will grab,
+  sort, and rename downloaded issues. It will also allow you to monitor weekly pull-lists
+  for items belonging to said watchlisted series to download, as well as being able
+  to monitor and maintain story-arcs.
+maintainer: Mylar3 Team <auto-converted@casaos.io>
+name: mylar3
+package_name: casaos-mylar3-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mylar3/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mylar3/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mylar3/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Mylar3/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/myspeed/config.yml
+++ b/sources/casaos-official/apps/myspeed/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/myspeed/docker-compose.yml
+++ b/sources/casaos-official/apps/myspeed/docker-compose.yml
@@ -1,0 +1,12 @@
+name: myspeed
+services:
+  myspeed:
+    image: germannewsmaker/myspeed:1.0.9
+    ports:
+    - protocol: tcp
+      published: 5216
+      target: 5216
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /myspeed/data
+      type: bind

--- a/sources/casaos-official/apps/myspeed/metadata.yaml
+++ b/sources/casaos-official/apps/myspeed/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: utils
+description: Analysis software that shows your internet speed for up to 30 days.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MySpeed/icon.png
+license: Unknown
+long_description: MySpeed is a speed test analysis software that stores the speed
+  of your internet for up to 30 days. This can also be useful if you want to know
+  when your network might have drops or if you want to check if your internet matches
+  the booked values from your contract.
+maintainer: Mathias Wagner <auto-converted@casaos.io>
+name: myspeed
+package_name: casaos-myspeed-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MySpeed/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MySpeed/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/MySpeed/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/n8n/config.yml
+++ b/sources/casaos-official/apps/n8n/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: 'false'
+    description: ''
+    id: N8N_SECURE_COOKIE
+    label: N8N_SECURE_COOKIE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/n8n/docker-compose.yml
+++ b/sources/casaos-official/apps/n8n/docker-compose.yml
@@ -1,0 +1,15 @@
+name: n8n
+services:
+  n8n:
+    environment:
+      N8N_SECURE_COOKIE: ${N8N_SECURE_COOKIE}
+      TZ: ${TZ}
+    image: n8nio/n8n:1.115.3
+    ports:
+    - protocol: tcp
+      published: 5678
+      target: 5678
+    volumes:
+    - source: /AppData/$AppID
+      target: /home/node/.n8n
+      type: bind

--- a/sources/casaos-official/apps/n8n/metadata.yaml
+++ b/sources/casaos-official/apps/n8n/metadata.yaml
@@ -1,0 +1,45 @@
+architecture: all
+debian_section: utils
+description: Workflow automation tool
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/N8n/icon.png
+license: Unknown
+long_description: "n8n is a powerful open-source workflow automation and conversational\
+  \ AI platform that blends the flexibility of coding with the simplicity of no-code\
+  \ development, empowering users to create efficient and secure automation workflows.\
+  \ It seamlessly connects any app with an API, leveraging native AI capabilities\
+  \ (like LangChain-based AI agent workflows) to process custom data, ideal for personal\
+  \ task management, team collaboration, or enterprise-grade automation. Its vibrant\
+  \ community offers over 400 integrations and 900+ ready-to-use templates, enabling\
+  \ users to deploy automations quickly.\n\nThe platform supports highly customizable\
+  \ workflow design, allowing users to write JavaScript/Python, add npm packages,\
+  \ or use an intuitive visual interface to manage data, catering to both simple tasks\
+  \ and complex processes. Enterprise-grade features like advanced permissions and\
+  \ air-gapped deployments ensure security, while multilingual support makes it accessible\
+  \ globally. n8n delivers a versatile and user-friendly automation solution.\n\n\
+  Discover n8n’s Automation Scenarios\nn8n’s community resources provide extensive\
+  \ support and inspiration, helping users explore its scenario-based value and easily\
+  \ build automation workflows. Below are two key resources showcasing n8n’s capabilities\
+  \ across various use cases:\n\n1. [n8n Official Community Forum](https://community.n8n.io/):\
+  \ \nThe forum is a hub for user collaboration and learning, offering resources from\
+  \ beginner guides to advanced workflow designs. Shared use cases include automating\
+  \ social media posts or real-time data syncing, such as using n8n to pull data from\
+  \ Google Sheets and send Slack notifications, boosting team collaboration and data\
+  \ efficiency.\n\n2. [n8n Official Template Library](https://n8n.io/workflows/):\
+  \ \nThe template library offers over 900 ready-to-use workflows for scenarios like\
+  \ marketing automation, data analytics, and customer support. For example, a template\
+  \ can link Shopify to Mailchimp, automatically adding new customers to mailing lists\
+  \ and sending welcome emails, making automation accessible to non-technical users.\
+  \ AI-driven workflows, like handling customer queries with LangChain, highlight\
+  \ n8n’s strength in intelligent interactions.\n"
+maintainer: n8n <auto-converted@casaos.io>
+name: n8n
+package_name: casaos-n8n-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/N8n/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/N8n/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/N8n/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/navidrome/config.yml
+++ b/sources/casaos-official/apps/navidrome/config.yml
@@ -1,0 +1,45 @@
+groups:
+- description: null
+  fields:
+  - default: 1h
+    description: Configure periodic scans using cron syntax.
+    id: ND_SCANSCHEDULE
+    label: ND_SCANSCHEDULE
+    required: false
+    type: string
+  - default: info
+    description: Log level.
+    id: ND_LOGLEVEL
+    label: ND_LOGLEVEL
+    required: false
+    type: string
+  - default: 24h
+    description: How long Navidrome will wait before closing web ui idle sessions
+    id: ND_SESSIONTIMEOUT
+    label: ND_SESSIONTIMEOUT
+    required: false
+    type: integer
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: ''
+    description: 'Base URL (only the path part) to configure Navidrome behind a proxy
+      (ex: /music)'
+    id: ND_BASEURL
+    label: ND_BASEURL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/navidrome/docker-compose.yml
+++ b/sources/casaos-official/apps/navidrome/docker-compose.yml
@@ -1,0 +1,21 @@
+name: navidrome
+services:
+  navidrome:
+    environment:
+      ND_BASEURL: ${ND_BASEURL}
+      ND_LOGLEVEL: ${ND_LOGLEVEL}
+      ND_SCANSCHEDULE: ${ND_SCANSCHEDULE}
+      ND_SESSIONTIMEOUT: ${ND_SESSIONTIMEOUT}
+      TZ: ${TZ}
+    image: deluan/navidrome:0.55.1
+    ports:
+    - protocol: tcp
+      published: 4533
+      target: 4533
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+    - source: /Media/Music
+      target: /music
+      type: bind

--- a/sources/casaos-official/apps/navidrome/metadata.yaml
+++ b/sources/casaos-official/apps/navidrome/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: video
+description: Music Collection and Streaming Server
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Navidrome/icon.png
+license: Unknown
+long_description: Navidrome is an open source web-based music collection server and
+  streamer. It gives you freedom to listen to your music collection from any browser
+  or mobile device. It's like your personal Spotify!
+maintainer: Unknown <auto-converted@casaos.io>
+name: navidrome
+package_name: casaos-navidrome-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Navidrome/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Navidrome/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/netdata/config.yml
+++ b/sources/casaos-official/apps/netdata/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/netdata/docker-compose.yml
+++ b/sources/casaos-official/apps/netdata/docker-compose.yml
@@ -1,0 +1,36 @@
+name: netdata
+services:
+  app:
+    image: netdata/netdata:stable
+    ports:
+    - protocol: tcp
+      published: 19999
+      target: 19999
+    volumes:
+    - source: /AppData/Netdata/config
+      target: /etc/netdata
+      type: bind
+    - source: /AppData/Netdata/lib
+      target: /var/lib/netdata
+      type: bind
+    - source: /AppData/Netdata/cache
+      target: /var/cache/netdata
+      type: bind
+    - source: /etc/passwd
+      target: /host/etc/passwd
+      type: bind
+    - source: /etc/group
+      target: /host/etc/group
+      type: bind
+    - source: /proc
+      target: /host/proc
+      type: bind
+    - source: /sys
+      target: /host/sys
+      type: bind
+    - source: /etc/os-release
+      target: /host/etc/os-release
+      type: bind
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind

--- a/sources/casaos-official/apps/netdata/metadata.yaml
+++ b/sources/casaos-official/apps/netdata/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: utils
+description: Real-time Performance Monitoring
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Netdata/icon.png
+license: Unknown
+long_description: Netdata is a real-time performance and health monitoring solution
+  that helps you visualize and understand the behavior of your systems.
+maintainer: Unknown <auto-converted@casaos.io>
+name: netdata
+package_name: casaos-netdata-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Netdata/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Netdata/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Netdata/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/nextcloud/config.yml
+++ b/sources/casaos-official/apps/nextcloud/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/nextcloud/docker-compose.yml
+++ b/sources/casaos-official/apps/nextcloud/docker-compose.yml
@@ -1,0 +1,15 @@
+name: nextcloud
+services:
+  nextcloud:
+    image: nextcloud:31.0
+    ports:
+    - protocol: tcp
+      published: 10081
+      target: 80
+    - protocol: tcp
+      published: 10443
+      target: 443
+    volumes:
+    - source: /AppData/$AppID/var/www/html
+      target: /var/www/html
+      type: bind

--- a/sources/casaos-official/apps/nextcloud/metadata.yaml
+++ b/sources/casaos-official/apps/nextcloud/metadata.yaml
@@ -1,0 +1,38 @@
+architecture: all
+debian_section: net
+description: Content collaboration platform
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/icon.png
+license: Unknown
+long_description: 'Discover the ultimate solution for remote collaboration with Nextcloud.
+  Unlike traditional office software, Nextcloud seamlessly integrates files, communication,
+  and productivity tools into one platform, enhancing teamwork and streamlining your
+  workflow. Say goodbye to the limitations of conventional tools and embrace a new
+  era of collaboration.
+
+
+  Nextcloud stands out with its robust features tailored for every need. Enjoy secure
+  file storage, real-time communication via Talk, comprehensive groupware, and powerful
+  office integration, all in one place. Experience these top-notch features at an
+  affordable price, making it accessible for everyone to elevate their collaboration
+  game.
+
+
+  Deploying Nextcloud on a Zima private cloud device brings unparalleled convenience.
+  Benefit from unlimited storage, secure data privacy, local network speeds, and multi-device
+  access, ensuring you have everything you need at your fingertips.
+
+  '
+maintainer: Nextcloud <auto-converted@casaos.io>
+name: nextcloud
+package_name: casaos-nextcloud-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nextcloud/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/nginxproxymanager/config.yml
+++ b/sources/casaos-official/apps/nginxproxymanager/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/nginxproxymanager/docker-compose.yml
+++ b/sources/casaos-official/apps/nginxproxymanager/docker-compose.yml
@@ -1,0 +1,21 @@
+name: nginxproxymanager
+services:
+  nginxproxymanager:
+    image: jc21/nginx-proxy-manager:2.12.3
+    ports:
+    - protocol: tcp
+      published: 80
+      target: 80
+    - protocol: tcp
+      published: 443
+      target: 443
+    - protocol: tcp
+      published: 81
+      target: 81
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind
+    - source: /AppData/$AppID/etc/letsencrypt
+      target: /etc/letsencrypt
+      type: bind

--- a/sources/casaos-official/apps/nginxproxymanager/metadata.yaml
+++ b/sources/casaos-official/apps/nginxproxymanager/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: net
+description: Managing Nginx proxy hosts with a simple, powerful interface.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/NginxProxyManager/icon.png
+license: Unknown
+long_description: Nginx Proxy Manager is a simple, powerful tool to help you host
+  multiple websites on a single server.
+maintainer: Nginx Proxy Manager <auto-converted@casaos.io>
+name: nginxproxymanager
+package_name: casaos-nginxproxymanager-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/NginxProxyManager/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/NginxProxyManager/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/NginxProxyManager/screenshot-3.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/node-red/config.yml
+++ b/sources/casaos-official/apps/node-red/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/node-red/docker-compose.yml
+++ b/sources/casaos-official/apps/node-red/docker-compose.yml
@@ -1,0 +1,12 @@
+name: node-red
+services:
+  node-red:
+    image: nodered/node-red:4.0.9-22
+    ports:
+    - protocol: tcp
+      published: 1880
+      target: 1880
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/node-red/metadata.yaml
+++ b/sources/casaos-official/apps/node-red/metadata.yaml
@@ -1,0 +1,63 @@
+architecture: all
+debian_section: devel
+description: Low-code programming for event-driven applications
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Node-RED/icon.png
+license: Unknown
+long_description: 'Node-RED is a flow-based low-code development platform that enables
+  creating automation tasks and applications by connecting various nodes. A browser-based
+  editor, simple to use, makes it ideal for users in home automation, industrial control,
+  or other fields to quickly build data processing flows.
+
+
+  Core features include a low-code flow editor and robust data handling. Built on
+  Node.js with an event-driven, non-blocking model, the platform supports real-time
+  data collection, transformation, and visualization. A palette with over 5000 nodes
+  allows users to construct flows via drag-and-drop. A rich text editor enables creating
+  JavaScript functions for enhanced customization.
+
+
+  It stores flows in JSON format, facilitating easy import and export for sharing.
+  A built-in library allows saving useful functions, templates, or flows for reuse,
+  and an online flow library supports sharing top flows globally. With ease of use
+  and efficiency at the core, the platform delivers a modern solution for diverse
+  automation needs.
+
+
+  **Key Features:**
+
+  - Browser-based low-code flow editor with drag-and-drop node connections
+
+  - Real-time data collection, transformation, and visualization
+
+  - Event-driven, non-blocking model with Node.js
+
+  - Palette with over 5000 nodes for extended functionality
+
+  - Rich text editor for creating JavaScript functions
+
+  - JSON-based flow storage for easy sharing
+
+  - Built-in library for saving functions, templates, and flows
+
+  - Online flow library for sharing top flows
+
+
+  **Learn More:**
+
+  - [Node-RED Official Website](https://nodered.org/)
+
+  - [Node-RED GitHub](https://github.com/node-red/node-red)
+
+  '
+maintainer: Node-RED <auto-converted@casaos.io>
+name: node-red
+package_name: casaos-node-red-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Node-RED/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Node-RED/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Node-RED/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/nzbget/config.yml
+++ b/sources/casaos-official/apps/nzbget/config.yml
@@ -1,0 +1,48 @@
+groups:
+- description: null
+  fields:
+  - default: tegbzn6789
+    description: ''
+    id: NZBGET_PASS
+    label: NZBGET_PASS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: nzbget
+    description: ''
+    id: NZBGET_USER
+    label: NZBGET_USER
+    required: false
+    type: string
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/nzbget/docker-compose.yml
+++ b/sources/casaos-official/apps/nzbget/docker-compose.yml
@@ -1,0 +1,21 @@
+name: nzbget
+services:
+  nzbget:
+    environment:
+      NZBGET_PASS: ${NZBGET_PASS}
+      NZBGET_USER: ${NZBGET_USER}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/nzbget:24.8.20250318
+    ports:
+    - protocol: tcp
+      published: 6789
+      target: 6789
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/nzbget/metadata.yaml
+++ b/sources/casaos-official/apps/nzbget/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: misc
+description: Efficient Usenet downloader
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nzbget/icon.png
+license: Unknown
+long_description: NZBGet can run on almost any device - classic PC, NAS, media player,
+  SAT-receiver, WLAN-router, etc. The download area provides precompiled binaries
+  for Windows, macOS, Linux (compatible with many CPUs and platform variants), FreeBSD
+  and Android. For other platforms the program can be compiled from sources.
+maintainer: Nzbget Team <auto-converted@casaos.io>
+name: nzbget
+package_name: casaos-nzbget-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nzbget/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nzbget/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nzbget/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Nzbget/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/obsidian/config.yml
+++ b/sources/casaos-official/apps/obsidian/config.yml
@@ -1,0 +1,45 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: User ID for file permissions
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: Group ID for file permissions
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: System timezone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: HTTP Basic auth username, abc is default.
+    id: CUSTOM_USER
+    label: CUSTOM_USER
+    required: false
+    type: string
+  - default: casaos
+    description: HTTP Basic auth password, abc is default. If unset there will be
+      no auth.
+    id: PASSWORD
+    label: PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/obsidian/docker-compose.yml
+++ b/sources/casaos-official/apps/obsidian/docker-compose.yml
@@ -1,0 +1,21 @@
+name: obsidian
+services:
+  obsidian:
+    environment:
+      CUSTOM_USER: ${CUSTOM_USER}
+      PASSWORD: ${PASSWORD}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: lscr.io/linuxserver/obsidian:1.8.10
+    ports:
+    - protocol: tcp
+      published: 15323
+      target: 3000
+    - protocol: tcp
+      published: 15324
+      target: 3001
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/obsidian/metadata.yaml
+++ b/sources/casaos-official/apps/obsidian/metadata.yaml
@@ -1,0 +1,69 @@
+architecture: all
+debian_section: text
+description: Obsidian is a knowledge management app for creating, linking
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Obsidian/icon.png
+license: Unknown
+long_description: 'Obsidian is a knowledge management app for creating, linking, and
+  visually organizing Markdown notes.
+
+
+  Obsidian is a self-hosted knowledge management app designed for creating, linking,
+  and organizing notes, operating on local Markdown files, leveraging WebDAV and kasmVNC
+  remote desktop technology to deliver a near-native experience in browsers. Its intuitive
+  interface supports storing and editing notes on devices, ensuring full data ownership,
+  ideal for crafting a lasting second brain.
+
+
+  The app''s core features include robust note management and connectivity, suitable
+  for various scenarios. Bi-directional linking connects related notes, forming a
+  web of knowledge, while the Graph View visualizes note relationships, helping users
+  uncover hidden connections. It supports Markdown editing with live preview for easy
+  formatting and structuring. Hundreds of community plugins and themes offer extended
+  functionality, such as calendars, kanban boards, PDF annotation, and advanced search,
+  enabling tailored workflows. The Canvas feature provides infinite visual organization
+  space, aiding students in organizing research, writers in developing stories, or
+  professionals in managing projects. Notes are stored as standard Markdown files,
+  openable with any text editor, ensuring future-proof portability.
+
+
+  It enhances usability through community-provided documentation, and whether for
+  personal knowledge bases or team collaboration, the app''s high flexibility and
+  intuitive operation offer a modern knowledge management solution.
+
+
+  **Key Features:**
+
+  - Local storage, ensuring full data ownership
+
+  - Bi-directional note linking for a knowledge web
+
+  - Graph View for visualizing note connections
+
+  - Extensible plugin system for personalized needs
+
+  - Markdown support with live preview
+
+  - Infinite Canvas for visual organization
+
+  - Theme customization for enhanced visuals
+
+
+  **Learn More:**
+
+  - [Obsidian Official Website](https://obsidian.md)
+
+  - [DockerHub](https://hub.docker.com/r/linuxserver/obsidian)
+
+  '
+maintainer: linuxserver <auto-converted@casaos.io>
+name: obsidian
+package_name: casaos-obsidian-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Obsidian/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Obsidian/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Obsidian/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ollama-nvidia/config.yml
+++ b/sources/casaos-official/apps/ollama-nvidia/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/ollama-nvidia/docker-compose.yml
+++ b/sources/casaos-official/apps/ollama-nvidia/docker-compose.yml
@@ -1,0 +1,12 @@
+name: ollama-nvidia
+services:
+  ollama:
+    image: ollama/ollama:0.9.5
+    ports:
+    - protocol: tcp
+      published: 11434
+      target: 11434
+    volumes:
+    - source: /AppData/$AppID/
+      target: /root/.ollama
+      type: bind

--- a/sources/casaos-official/apps/ollama-nvidia/metadata.yaml
+++ b/sources/casaos-official/apps/ollama-nvidia/metadata.yaml
@@ -1,0 +1,100 @@
+architecture: all
+debian_section: comm
+description: Get up and running with large language models locally
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/icon.png
+license: Unknown
+long_description: 'Ollama is a tool for running large language models locally, designed
+  to help users quickly deploy and manage AI models via a simple command-line interface
+  and server. Its intuitive Web interface and efficient design make it ideal for developers,
+  researchers, and AI enthusiasts working on local hardware.
+
+
+  The tool''s core features include local model execution and multi-model support.
+  It enables running models like Llama 3, Mistral, and Gemma, with simple commands
+  for downloading and switching models. All data processing occurs locally, ensuring
+  privacy. Low resource usage optimizes model loading, allowing smooth operation on
+  limited hardware.
+
+
+  It offers a RESTful API for application integration and supports tool calling (e.g.,
+  Llama 3.1) for complex tasks. Model management via Modelfile bundles weights and
+  configurations for ease of use. The tool''s efficiency and user control deliver
+  a modern local AI solution.
+
+
+  **Key Features:**
+
+  - **Local Execution**: Run LLMs directly on your hardware without internet dependency
+
+  - **Multiple Model Support**: Access to dozens of pre-trained models including Llama
+  3, Mistral, Gemma, Code Llama, and more
+
+  - **Easy Model Management**: Simple commands to pull, run, and manage different
+  models
+
+  - **API Integration**: RESTful API for building applications and integrations
+
+  - **Memory Efficient**: Optimized model loading and memory management
+
+  - **Privacy-Focused**: All processing happens locally, ensuring data privacy
+
+
+  **Supported Models:**
+
+  - DeepSeek-R1 (1.5B, 7B, 8B, 14B, 32B, 70B, 671B parameters)
+
+  - Gemma3n (2B, 4B parameters)
+
+  - Gemma3 (1B, 4B, 12B, 27B parameters)
+
+  - Qwen3 (0.6B, 1.7B, 4B, 8B, 14B, 30B, 32B, 235B parameters)
+
+  - Qwen2.5vl (3B, 7B, 32B, 72B parameters)
+
+  - Llama3.1 (8B, 70B, 405B parameters)
+
+  - Llama3.2 (1B, 3B parameters)
+
+  - Mistral (7B parameters)
+
+  - And many more...
+
+
+  **Use Cases:**
+
+  - Local AI development and experimentation
+
+  - Educational purposes and research
+
+  - Building AI-powered applications
+
+  - Code generation and assistance
+
+  - Text generation and completion
+
+  - Chatbots and conversational AI
+
+  - Data analysis and insights
+
+
+  **Learn More:**
+
+  - [Ollama Official Website](https://ollama.com/)
+
+  - [Ollama GitHub Repository](https://github.com/ollama/ollama)
+
+  - [Model Library](https://ollama.com/library)
+
+  '
+maintainer: ollama <auto-converted@casaos.io>
+name: ollama-nvidia
+package_name: casaos-ollama-nvidia-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ollama/config.yml
+++ b/sources/casaos-official/apps/ollama/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/ollama/docker-compose.yml
+++ b/sources/casaos-official/apps/ollama/docker-compose.yml
@@ -1,0 +1,12 @@
+name: ollama
+services:
+  ollama:
+    image: ollama/ollama:0.9.5
+    ports:
+    - protocol: tcp
+      published: 11434
+      target: 11434
+    volumes:
+    - source: /AppData/$AppID/
+      target: /root/.ollama
+      type: bind

--- a/sources/casaos-official/apps/ollama/metadata.yaml
+++ b/sources/casaos-official/apps/ollama/metadata.yaml
@@ -1,0 +1,100 @@
+architecture: all
+debian_section: comm
+description: Get up and running with large language models locally
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/icon.png
+license: Unknown
+long_description: 'Ollama is a tool for running large language models locally, designed
+  to help users quickly deploy and manage AI models via a simple command-line interface
+  and server. Its intuitive Web interface and efficient design make it ideal for developers,
+  researchers, and AI enthusiasts working on local hardware.
+
+
+  The tool''s core features include local model execution and multi-model support.
+  It enables running models like Llama 3, Mistral, and Gemma, with simple commands
+  for downloading and switching models. All data processing occurs locally, ensuring
+  privacy. Low resource usage optimizes model loading, allowing smooth operation on
+  limited hardware.
+
+
+  It offers a RESTful API for application integration and supports tool calling (e.g.,
+  Llama 3.1) for complex tasks. Model management via Modelfile bundles weights and
+  configurations for ease of use. The tool''s efficiency and user control deliver
+  a modern local AI solution.
+
+
+  **Key Features:**
+
+  - **Local Execution**: Run LLMs directly on your hardware without internet dependency
+
+  - **Multiple Model Support**: Access to dozens of pre-trained models including Llama
+  3, Mistral, Gemma, Code Llama, and more
+
+  - **Easy Model Management**: Simple commands to pull, run, and manage different
+  models
+
+  - **API Integration**: RESTful API for building applications and integrations
+
+  - **Memory Efficient**: Optimized model loading and memory management
+
+  - **Privacy-Focused**: All processing happens locally, ensuring data privacy
+
+
+  **Supported Models:**
+
+  - DeepSeek-R1 (1.5B, 7B, 8B, 14B, 32B, 70B, 671B parameters)
+
+  - Gemma3n (2B, 4B parameters)
+
+  - Gemma3 (1B, 4B, 12B, 27B parameters)
+
+  - Qwen3 (0.6B, 1.7B, 4B, 8B, 14B, 30B, 32B, 235B parameters)
+
+  - Qwen2.5vl (3B, 7B, 32B, 72B parameters)
+
+  - Llama3.1 (8B, 70B, 405B parameters)
+
+  - Llama3.2 (1B, 3B parameters)
+
+  - Mistral (7B parameters)
+
+  - And many more...
+
+
+  **Use Cases:**
+
+  - Local AI development and experimentation
+
+  - Educational purposes and research
+
+  - Building AI-powered applications
+
+  - Code generation and assistance
+
+  - Text generation and completion
+
+  - Chatbots and conversational AI
+
+  - Data analysis and insights
+
+
+  **Learn More:**
+
+  - [Ollama Official Website](https://ollama.com/)
+
+  - [Ollama GitHub Repository](https://github.com/ollama/ollama)
+
+  - [Model Library](https://ollama.com/library)
+
+  '
+maintainer: ollama <auto-converted@casaos.io>
+name: ollama
+package_name: casaos-ollama-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ollama/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ombi/config.yml
+++ b/sources/casaos-official/apps/ombi/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: /ombi
+    description: ''
+    id: BASE_URL
+    label: BASE_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/ombi/docker-compose.yml
+++ b/sources/casaos-official/apps/ombi/docker-compose.yml
@@ -1,0 +1,17 @@
+name: ombi
+services:
+  ombi:
+    environment:
+      BASE_URL: ${BASE_URL}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/ombi:4.47.1
+    ports:
+    - protocol: tcp
+      published: 3579
+      target: 3579
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/ombi/metadata.yaml
+++ b/sources/casaos-official/apps/ombi/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: video
+description: Friendly media request tool, automatically syncs with your media servers!
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ombi/icon.png
+license: Unknown
+long_description: Ombi is a self-hosted web application that automatically gives your
+  shared Plex or Emby users the ability to request content by themselves! Ombi can
+  be linked to multiple TV Show and Movie DVR tools to create a seamless end-to-end
+  experience for your users.
+maintainer: Sabnzbd Team <auto-converted@casaos.io>
+name: ombi
+package_name: casaos-ombi-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ombi/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ombi/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ombi/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/open-webui-ollama/config.yml
+++ b/sources/casaos-official/apps/open-webui-ollama/config.yml
@@ -1,0 +1,18 @@
+groups:
+- description: null
+  fields:
+  - default: 'true'
+    description: ''
+    id: CPU_FALLBACK
+    label: CPU_FALLBACK
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: NVIDIA_VISIBLE_DEVICES
+    label: NVIDIA_VISIBLE_DEVICES
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/open-webui-ollama/docker-compose.yml
+++ b/sources/casaos-official/apps/open-webui-ollama/docker-compose.yml
@@ -1,0 +1,18 @@
+name: open-webui-ollama
+services:
+  open-webui-ollama:
+    environment:
+      CPU_FALLBACK: ${CPU_FALLBACK}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES}
+    image: ghcr.io/open-webui/open-webui:ollama
+    ports:
+    - protocol: tcp
+      published: 3050
+      target: 8080
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/open-webui
+      target: /app/backend/data
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/ollama
+      target: /root/.ollama
+      type: bind

--- a/sources/casaos-official/apps/open-webui-ollama/metadata.yaml
+++ b/sources/casaos-official/apps/open-webui-ollama/metadata.yaml
@@ -1,0 +1,69 @@
+architecture: all
+debian_section: comm
+description: User-friendly WebUI for LLMs (Formerly Ollama WebUI)
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenWebUI/icon.png
+license: Unknown
+long_description: 'Open WebUI is a feature-rich, user-friendly self-hosted AI platform
+  designed for fully offline operation, supporting multiple large language model runners
+  and API integration. Its intuitive Web interface provides powerful AI deployment
+  capabilities, ideal for developers, researchers, and AI enthusiasts building localized
+  intelligent applications.
+
+
+  The tool''s core features include local model execution and Retrieval Augmented
+  Generation (RAG). It supports Ollama and OpenAI-compatible APIs (e.g., LMStudio,
+  GroqCloud), enabling seamless model switching and multi-model conversations. RAG
+  enhances chat experiences through local document loading or web search integration
+  (e.g., SearXNG, Google PSE). Granular permissions and role-based access control
+  (RBAC) ensure security with customized user role management.
+
+
+  It supports Markdown and LaTeX for enriched interactions and offers hands-free voice
+  and video call features for dynamic communication. Image generation integration
+  (e.g., DALL-E, ComfyUI) enriches visual content, and a model builder enables creating
+  and importing custom models via the interface. The Pipelines plugin framework supports
+  Python plugins, extending functionality like function calling and real-time translation.
+  The tool’s offline privacy and flexibility deliver a modern AI interaction solution.
+
+
+  **Key Features:**
+
+  - Local execution of Ollama and OpenAI-compatible APIs with multi-model conversations
+
+  - RAG support with local document and web search integration (e.g., SearXNG, Google
+  PSE)
+
+  - Granular permissions and role-based access control (RBAC)
+
+  - Simultaneous interaction with multiple models, leveraging their strengths
+
+  - Image generation integration with DALL-E, ComfyUI, and more
+
+  - Full Markdown and LaTeX support
+
+  - Hands-free voice and video call functionality
+
+  - Pipelines plugin framework for custom Python functionality
+
+
+  **Learn More:**
+
+  - [Open WebUI Official Website](https://openwebui.com)
+
+  - [Open WebUI Documentation](https://docs.openwebui.com)
+
+  - [Open WebUI GitHub Repository](https://github.com/open-webui/open-webui)
+
+  '
+maintainer: Tim J. Baek <auto-converted@casaos.io>
+name: open-webui-ollama
+package_name: casaos-open-webui-ollama-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenWebUI/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenWebUI/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenWebUI/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/openhab/config.yml
+++ b/sources/casaos-official/apps/openhab/config.yml
@@ -1,0 +1,32 @@
+groups:
+- description: null
+  fields:
+  - default: unlimited
+    description: Crypto Policy
+    id: CRYPTO_POLICY
+    label: CRYPTO_POLICY
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $PGID
+    description: Run OpenHAB as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run OpenHAB as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/openhab/docker-compose.yml
+++ b/sources/casaos-official/apps/openhab/docker-compose.yml
@@ -1,0 +1,26 @@
+name: openhab
+services:
+  openhab:
+    environment:
+      CRYPTO_POLICY: ${CRYPTO_POLICY}
+      PGID: ${PGID}
+      PUID: ${PUID}
+    image: openhab/openhab:4.3.3
+    volumes:
+    - read_only: true
+      source: /etc/localtime
+      target: /etc/localtime
+      type: bind
+    - read_only: true
+      source: /etc/timezone
+      target: /etc/timezone
+      type: bind
+    - source: /AppData/$AppID/addons
+      target: /openhab/addons
+      type: bind
+    - source: /AppData/$AppID/conf
+      target: /openhab/conf
+      type: bind
+    - source: /AppData/$AppID/userdata
+      target: /openhab/userdata
+      type: bind

--- a/sources/casaos-official/apps/openhab/metadata.yaml
+++ b/sources/casaos-official/apps/openhab/metadata.yaml
@@ -1,0 +1,27 @@
+architecture: all
+debian_section: misc
+description: Empowering the smart home
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHAB/icon.png
+license: Unknown
+long_description: The open Home Automation Bus (openHAB, pronounced ˈəʊpənˈhæb) is
+  an open source, technology agnostic home automation platform which runs as the center
+  of your smart home! Its ability to integrate a multitude of other devices and systems.
+  openHAB includes other home automation systems, (smart) devices and other technologies
+  into a single solution. To provide a uniform user interface and a common approach
+  to automation rules across the entire system, regardless of the number of manufacturers
+  and sub-systems involved. Giving you the most flexible tool available to make almost
+  any home automation wish come true; if you can think it, odds are that you can implement
+  it with openHAB.
+maintainer: openHAB <auto-converted@casaos.io>
+name: openhab
+package_name: casaos-openhab-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHAB/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHAB/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHAB/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHAB/screenshot-4.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/openhands/config.yml
+++ b/sources/casaos-official/apps/openhands/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: docker.all-hands.dev/all-hands-ai/runtime:0.49-nikolaik
+    description: Container Image for Runtime Environment
+    id: SANDBOX_RUNTIME_CONTAINER_IMAGE
+    label: SANDBOX_RUNTIME_CONTAINER_IMAGE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: /DATA/AppData/$AppID/workspace
+    description: Mount Path for Workspace Directory
+    id: WORKSPACE_MOUNT_PATH
+    label: WORKSPACE_MOUNT_PATH
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/openhands/docker-compose.yml
+++ b/sources/casaos-official/apps/openhands/docker-compose.yml
@@ -1,0 +1,21 @@
+name: openhands
+services:
+  openhands:
+    environment:
+      SANDBOX_RUNTIME_CONTAINER_IMAGE: ${SANDBOX_RUNTIME_CONTAINER_IMAGE}
+      WORKSPACE_MOUNT_PATH: ${WORKSPACE_MOUNT_PATH}
+    image: docker.all-hands.dev/all-hands-ai/openhands:0.49
+    ports:
+    - protocol: tcp
+      published: 13333
+      target: 3000
+    volumes:
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind
+    - source: /AppData/$AppID/openhands
+      target: /.openhands
+      type: bind
+    - source: /AppData/$AppID/workspace
+      target: /opt/workspace_base
+      type: bind

--- a/sources/casaos-official/apps/openhands/metadata.yaml
+++ b/sources/casaos-official/apps/openhands/metadata.yaml
@@ -1,0 +1,47 @@
+architecture: all
+debian_section: misc
+description: Open-source AI-powered coding assistant
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHands/icon.png
+license: Unknown
+long_description: 'OpenHands is an open-source AI-powered coding assistant that provides
+  developers with intelligent code completion, generation, and debugging capabilities.
+  It runs in a sandboxed environment to ensure security and isolation while allowing
+  access to various development tools and resources.
+
+
+  **Key Features:**
+
+  - AI-powered code completion and generation
+
+  - Interactive debugging and error resolution
+
+  - Support for multiple programming languages
+
+  - Secure sandboxed execution environment
+
+  - Customizable runtime configurations
+
+  - Integration with Docker for containerized workflows
+
+
+  **Learn More:**
+
+  - [OpenHands Official Website](https://www.all-hands.dev)
+
+  - [OpenHands GitHub Repository](https://github.com/All-Hands-AI/OpenHands)
+
+  - [Documentation](https://docs.all-hands.dev)
+
+  '
+maintainer: All-Hands-AI <auto-converted@casaos.io>
+name: openhands
+package_name: casaos-openhands-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHands/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHands/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenHands/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/openspeedtest/config.yml
+++ b/sources/casaos-official/apps/openspeedtest/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/openspeedtest/docker-compose.yml
+++ b/sources/casaos-official/apps/openspeedtest/docker-compose.yml
@@ -1,0 +1,8 @@
+name: openspeedtest
+services:
+  openspeedtest:
+    image: openspeedtest/latest:v2.0.6
+    ports:
+    - protocol: tcp
+      published: 3004
+      target: 3000

--- a/sources/casaos-official/apps/openspeedtest/metadata.yaml
+++ b/sources/casaos-official/apps/openspeedtest/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: utils
+description: HTML5 Network Speed Test Server.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenSpeedTest/icon.png
+license: Unknown
+long_description: An application for launching HTML5 Network Speed Test Server. You
+  can test download & upload speed from any device within your network with a web
+  browser that is IE10 or new.
+maintainer: OpenSpeedTest <auto-converted@casaos.io>
+name: openspeedtest
+package_name: casaos-openspeedtest-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenSpeedTest/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenSpeedTest/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/OpenSpeedTest/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/overseerr/config.yml
+++ b/sources/casaos-official/apps/overseerr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: Specify a timezone to use, see this list.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/overseerr/docker-compose.yml
+++ b/sources/casaos-official/apps/overseerr/docker-compose.yml
@@ -1,0 +1,16 @@
+name: overseerr
+services:
+  overseerr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/overseerr:1.33.2
+    ports:
+    - protocol: tcp
+      published: 5055
+      target: 5055
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/overseerr/metadata.yaml
+++ b/sources/casaos-official/apps/overseerr/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: video
+description: Overseerr is a request management and media discovery tool built to work...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Overseerr/icon.png
+license: Unknown
+long_description: 'Overseerr is a request management and media discovery tool built
+  to work with your existing Plex ecosystem.
+
+
+  Overseerr is a free and open source software application for managing requests for
+  your media library. It integrates with your existing services, such as Sonarr, Radarr,
+  and Plex!'
+maintainer: LinuxServer.io <auto-converted@casaos.io>
+name: overseerr
+package_name: casaos-overseerr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Overseerr/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Overseerr/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Overseerr/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/pdfding/config.yml
+++ b/sources/casaos-official/apps/pdfding/config.yml
@@ -1,0 +1,40 @@
+groups:
+- description: null
+  fields:
+  - default: '*'
+    description: ''
+    id: HOST_NAME
+    label: HOST_NAME
+    required: false
+    type: string
+  - default: 'FALSE'
+    description: ''
+    id: CSRF_COOKIE_SECURE
+    label: CSRF_COOKIE_SECURE
+    required: false
+    type: string
+  - default: 'FALSE'
+    description: ''
+    id: SESSION_COOKIE_SECURE
+    label: SESSION_COOKIE_SECURE
+    required: false
+    type: string
+  - default: 'FALSE'
+    description: ''
+    id: DEBUG
+    label: DEBUG
+    required: false
+    type: boolean
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: your_secret_key_here
+    description: ''
+    id: SECRET_KEY
+    label: SECRET_KEY
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/pdfding/docker-compose.yml
+++ b/sources/casaos-official/apps/pdfding/docker-compose.yml
@@ -1,0 +1,21 @@
+name: pdfding
+services:
+  pdfding:
+    environment:
+      CSRF_COOKIE_SECURE: ${CSRF_COOKIE_SECURE}
+      DEBUG: ${DEBUG}
+      HOST_NAME: ${HOST_NAME}
+      SECRET_KEY: ${SECRET_KEY}
+      SESSION_COOKIE_SECURE: ${SESSION_COOKIE_SECURE}
+    image: mrmn/pdfding:v1.3.1
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    volumes:
+    - source: /AppData/$AppID/db
+      target: /home/nonroot/pdfding/db
+      type: bind
+    - source: /AppData/$AppID/media
+      target: /home/nonroot/pdfding/media
+      type: bind

--- a/sources/casaos-official/apps/pdfding/metadata.yaml
+++ b/sources/casaos-official/apps/pdfding/metadata.yaml
@@ -1,0 +1,34 @@
+architecture: all
+debian_section: text
+description: Selfhosted PDF manager, viewer and editor
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PdfDing/icon.png
+license: Unknown
+long_description: 'PdfDing is a selfhosted PDF manager, viewer and editor offering
+  a seamless user experience on multiple devices. It''s designed to be minimal, fast,
+  and easy to set up using Docker.
+
+
+  With features like seamless browser-based PDF viewing that remembers your current
+  position, multi-level tagging, starring and archiving functionalities, PDF editing
+  with comments, highlighting and drawings, clean intuitive UI with dark mode, SSO
+  support via OIDC, PDF sharing with external audience, markdown notes, and progress
+  bars showing reading progress, PdfDing ensures an excellent PDF management experience.
+
+
+  Deploying PdfDing on private cloud devices like Zima brings unmatched convenience
+  with multi-device access, ensuring your PDF collection is always within reach and
+  secure, no matter where you are.
+
+  '
+maintainer: mrmn2 <auto-converted@casaos.io>
+name: pdfding
+package_name: casaos-pdfding-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PdfDing/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PdfDing/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PdfDing/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/petio/config.yml
+++ b/sources/casaos-official/apps/petio/config.yml
@@ -1,0 +1,50 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: specify a timezone to use.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/petio/docker-compose.yml
+++ b/sources/casaos-official/apps/petio/docker-compose.yml
@@ -1,0 +1,25 @@
+name: petio
+services:
+  mongo:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: mongo:4.4.22
+  petio:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: ghcr.io/petio-team/petio@sha256:1c5a9276a844f4284601cbe332905864950545ebdeaad74bacb9097ea4f4b333
+    ports:
+    - protocol: tcp
+      published: 7777
+      target: 7777
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /app/api/config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/logs
+      target: /app/logs
+      type: bind

--- a/sources/casaos-official/apps/petio/metadata.yaml
+++ b/sources/casaos-official/apps/petio/metadata.yaml
@@ -1,0 +1,35 @@
+architecture: all
+debian_section: video
+description: A third party companion app available to Plex server owners to allow
+  their...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Petio/icon.png
+license: Unknown
+long_description: 'A third party companion app available to Plex server owners to
+  allow their users to request, review and discover content.
+
+
+  Petio is a third party companion app available to Plex server owners to allow their
+  users to request, review and discover content. The app is built to appear instantly
+  familiar and intuitive to even the most tech-agnostic users. Petio will help you
+  manage requests from your users, connect to other third party apps such as Sonarr
+  and Radarr, notify users when content is available and track request progress. Petio
+  also allows users to discover media both on and off your server, quickly and easily
+  find related content and review to leave their opinion for other users.
+
+
+  Petio is an ongoing, forever free, always evolving project currently in alpha prototype
+  stage and now available!
+
+  '
+maintainer: Petio Team <auto-converted@casaos.io>
+name: petio
+package_name: casaos-petio-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Petio/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Petio/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Petio/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/photoprism/config.yml
+++ b/sources/casaos-official/apps/photoprism/config.yml
@@ -1,0 +1,32 @@
+groups:
+- description: null
+  fields:
+  - default: casaos
+    description: The password of admin
+    id: PHOTOPRISM_ADMIN_PASSWORD
+    label: PHOTOPRISM_ADMIN_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: 'true'
+    description: true or false, is it possible to upload NSFW
+    id: PHOTOPRISM_UPLOAD_NSFW
+    label: PHOTOPRISM_UPLOAD_NSFW
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/photoprism/docker-compose.yml
+++ b/sources/casaos-official/apps/photoprism/docker-compose.yml
@@ -1,0 +1,19 @@
+name: photoprism
+services:
+  photoprism:
+    environment:
+      PHOTOPRISM_ADMIN_PASSWORD: ${PHOTOPRISM_ADMIN_PASSWORD}
+      PHOTOPRISM_UPLOAD_NSFW: ${PHOTOPRISM_UPLOAD_NSFW}
+      TZ: ${TZ}
+    image: photoprism/photoprism:250228
+    ports:
+    - protocol: tcp
+      published: 2342
+      target: 2342
+    volumes:
+    - source: /AppData/$AppID/photoprism/storage
+      target: /photoprism/storage
+      type: bind
+    - source: /Gallery
+      target: /photoprism/originals
+      type: bind

--- a/sources/casaos-official/apps/photoprism/metadata.yaml
+++ b/sources/casaos-official/apps/photoprism/metadata.yaml
@@ -1,0 +1,42 @@
+architecture: all
+debian_section: misc
+description: Browse Your Life in Images
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PhotoPrism/icon.png
+license: Unknown
+long_description: 'Your AI-Powered Photos App for the Decentralized Web
+
+
+  PhotoPrism brings the magic of AI to your home TV, phone, and multiple devices,
+  revolutionizing the way you manage and share your photos. Unlike traditional photo
+  albums that require manual organization, PhotoPrism automatically tags and finds
+  your pictures, making it easier than ever to relive your memories. Whether you''re
+  showing family photos on your TV or sharing vacation snapshots on your phone, PhotoPrism
+  makes the experience seamless and enjoyable.
+
+
+  PhotoPrism offers a host of features designed to enhance your photo management experience.
+  With powerful search capabilities, automatic tagging, and a user-friendly interface,
+  you''ll find it easy to keep your photo collection organized. The app is free to
+  use, with premium options available for those seeking additional features and support.
+  Users can expect a smooth, intuitive experience that blends cutting-edge technology
+  with everyday convenience.
+
+
+  Deploying PhotoPrism on Zima private cloud devices offers unparalleled convenience.
+  Enjoy unlimited storage capacity, the speed of your local network, and access from
+  multiple devices without the need for the internet. It''s the perfect solution for
+  NAS enthusiasts who value privacy and performance.
+
+  '
+maintainer: PhotoPrism <auto-converted@casaos.io>
+name: photoprism
+package_name: casaos-photoprism-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PhotoPrism/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PhotoPrism/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PhotoPrism/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/pihole/config.yml
+++ b/sources/casaos-official/apps/pihole/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: Pi-hole admin password
+    id: FTLCONF_WEBSERVER_API_PASSWORD
+    label: FTLCONF_webserver_api_password
+    required: false
+    type: string
+  - default: all
+    description: DNS listening mode
+    id: FTLCONF_DNS_LISTENINGMODE
+    label: FTLCONF_dns_listeningMode
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/pihole/docker-compose.yml
+++ b/sources/casaos-official/apps/pihole/docker-compose.yml
@@ -1,0 +1,25 @@
+name: pihole
+services:
+  pihole:
+    environment:
+      FTLCONF_DNS_LISTENINGMODE: ${FTLCONF_DNS_LISTENINGMODE}
+      FTLCONF_WEBSERVER_API_PASSWORD: ${FTLCONF_WEBSERVER_API_PASSWORD}
+      TZ: ${TZ}
+    image: pihole/pihole:2025.07.1
+    ports:
+    - protocol: tcp
+      published: 8800
+      target: 80
+    - protocol: tcp
+      published: 53
+      target: 53
+    - protocol: udp
+      published: 53
+      target: 53
+    - protocol: tcp
+      published: 8443
+      target: 443
+    volumes:
+    - source: /AppData/$AppID/etc/pihole/
+      target: /etc/pihole
+      type: bind

--- a/sources/casaos-official/apps/pihole/metadata.yaml
+++ b/sources/casaos-official/apps/pihole/metadata.yaml
@@ -1,0 +1,61 @@
+architecture: all
+debian_section: net
+description: Network-wide Ad Blocking
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pihole/icon.png
+license: Unknown
+long_description: 'Pi-hole is a network-wide ad-blocking platform for Linux hardware,
+  using DNS sinkhole technology to protect devices from unwanted content without requiring
+  client-side software. Designed for home or enterprise networks, it offers efficient
+  ad blocking and network optimization.
+
+
+  Core features include network-wide ad blocking and content blocking in non-browser
+  environments. It uses DNS sinkhole to block ads, covering mobile apps and smart
+  TVs. Caching DNS queries speeds up everyday browsing. A command-line interface ensures
+  interoperability with reliable control options.
+
+
+  It provides an intuitive web interface dashboard for viewing and managing system
+  status. An optional DHCP server function automatically protects all devices. Capable
+  of handling high query volumes on server-grade hardware, it supports ad blocking
+  over IPv4 and IPv6. With efficiency and versatility at the core, the platform delivers
+  a modern network protection solution.
+
+
+  **Key Features:**
+
+  - Network-wide ad blocking via DNS sinkhole technology
+
+  - Blocking content in non-browser environments, including mobile apps and smart
+  TVs
+
+  - Caching DNS queries to speed up browsing
+
+  - Command-line interface for interoperability
+
+  - Intuitive web interface dashboard for system viewing and control
+
+  - Optional DHCP server function for automatic device protection
+
+  - Ad blocking support for IPv4 and IPv6
+
+
+  **Learn More:**
+
+  - [Pi-hole Official Website](https://pi-hole.net/)
+
+  - [Pi-hole GitHub](https://github.com/pi-hole/pi-hole)
+
+  '
+maintainer: Pi-hole <auto-converted@casaos.io>
+name: pihole
+package_name: casaos-pihole-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pihole/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pihole/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pihole/screenshot-3.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/pinchflat/config.yml
+++ b/sources/casaos-official/apps/pinchflat/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/pinchflat/docker-compose.yml
+++ b/sources/casaos-official/apps/pinchflat/docker-compose.yml
@@ -1,0 +1,19 @@
+name: pinchflat
+services:
+  pinchflat:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: ghcr.io/kieraneglin/pinchflat:latest
+    ports:
+    - protocol: tcp
+      published: 8945
+      target: 8945
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/pinchflat/metadata.yaml
+++ b/sources/casaos-official/apps/pinchflat/metadata.yaml
@@ -1,0 +1,59 @@
+architecture: all
+debian_section: video
+description: Your next YouTube media manager
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pinchflat/icon.png
+license: Unknown
+long_description: 'Pinchflat is a self-hosted app for downloading YouTube content
+  built using yt-dlp. It''s designed to be lightweight, self-contained, and easy to
+  use. You set up rules for how to download content from YouTube channels or playlists
+  and it''ll do the rest, periodically checking for new content.
+
+
+  Key features include:
+
+  - Self-contained - just one Docker container with no external dependencies
+
+  - Powerful naming system so content is stored where and how you want it
+
+  - Easy-to-use web interface with presets to get you started right away
+
+  - First-class support for media center apps like Plex, Jellyfin, and Kodi
+
+  - Supports serving RSS feeds to your favourite podcast app
+
+  - Automatically downloads new content from channels and playlists
+
+  - Supports downloading audio content
+
+  - Custom rules for handling YouTube Shorts and livestreams
+
+  - Apprise support for notifications
+
+  - Optionally automatically delete old content
+
+  - Advanced options like setting cutoff dates and filtering by title
+
+  - Reliable hands-off operation
+
+  - Can pass cookies to YouTube to download your private playlists
+
+  - Sponsorblock integration
+
+  - Supports running custom scripts when after downloading/deleting media
+
+
+  Perfect for people who want to download content for use with a media center app
+  or for those who want to archive media!
+
+  '
+maintainer: kieraneglin <auto-converted@casaos.io>
+name: pinchflat
+package_name: casaos-pinchflat-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pinchflat/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Pinchflat/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/playit-agent/config.yml
+++ b/sources/casaos-official/apps/playit-agent/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/playit-agent/docker-compose.yml
+++ b/sources/casaos-official/apps/playit-agent/docker-compose.yml
@@ -1,0 +1,4 @@
+name: playit-agent
+services:
+  playit-agent:
+    image: ghcr.io/mafen/playit-docker:latest

--- a/sources/casaos-official/apps/playit-agent/metadata.yaml
+++ b/sources/casaos-official/apps/playit-agent/metadata.yaml
@@ -1,0 +1,15 @@
+architecture: all
+debian_section: utils
+description: A free reverse proxy for tunneling services (not self-hosted).
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/playit-agent/icon.png
+license: Unknown
+long_description: A free reverse proxy for tunneling services (not self-hosted).
+maintainer: Patrick Lorio <auto-converted@casaos.io>
+name: playit-agent
+package_name: casaos-playit-agent-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/plex-nvidia/config.yml
+++ b/sources/casaos-official/apps/plex-nvidia/config.yml
@@ -1,0 +1,44 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Plex as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Plex as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: docker
+    description: Let Docker handle the Plex Version
+    id: VERSION
+    label: VERSION
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: CPU_FALLBACK
+    label: CPU_FALLBACK
+    required: false
+    type: string
+  - default: all
+    description: ''
+    id: NVIDIA_VISIBLE_DEVICES
+    label: NVIDIA_VISIBLE_DEVICES
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/plex-nvidia/docker-compose.yml
+++ b/sources/casaos-official/apps/plex-nvidia/docker-compose.yml
@@ -1,0 +1,17 @@
+name: plex-nvidia
+services:
+  plex:
+    environment:
+      CPU_FALLBACK: ${CPU_FALLBACK}
+      NVIDIA_VISIBLE_DEVICES: ${NVIDIA_VISIBLE_DEVICES}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      VERSION: ${VERSION}
+    image: lscr.io/linuxserver/plex:1.41.3
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media
+      target: /Media
+      type: bind

--- a/sources/casaos-official/apps/plex-nvidia/metadata.yaml
+++ b/sources/casaos-official/apps/plex-nvidia/metadata.yaml
@@ -1,0 +1,30 @@
+architecture: all
+debian_section: video
+description: Stream Movies & TV Shows
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/icon.png
+license: Unknown
+long_description: "Transform your home into a cinematic oasis with your very own media\
+  \ server. Unlike streaming platforms that compress and limit the quality of your\
+  \ content, a Plex server in your home allows you to maintain the pristine, high-bitrate\
+  \ glory of Blu-ray and beyond. Imagine pairing this high-fidelity, uninterrupted\
+  \ media access with cutting-edge home theater tech like VR headsets, 75-inch UHD\
+  \ TVs, or 100-inch laser projectors. The result? A breathtaking visual and auditory\
+  \ experience that streams seamlessly across TVs and mobile devices alike, right\
+  \ from the comfort of your couch. \n\nDeploy Plex on a Zima devices and unlock the\
+  \ ultimate in home entertainment convenience. Enjoy ALMOST limitless storage capacity\
+  \ for your entire media library, lightning-fast local network speeds, and the ability\
+  \ to stream content effortlessly to any device in your home. Experience a world\
+  \ where your favorite shows and movies are always just a click away, stored securely\
+  \ and privately on your own terms.\n"
+maintainer: Plex <auto-converted@casaos.io>
+name: plex-nvidia
+package_name: casaos-plex-nvidia-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/plex/config.yml
+++ b/sources/casaos-official/apps/plex/config.yml
@@ -1,0 +1,32 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Plex as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Plex as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: docker
+    description: Let Docker handle the Plex Version
+    id: VERSION
+    label: VERSION
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/plex/docker-compose.yml
+++ b/sources/casaos-official/apps/plex/docker-compose.yml
@@ -1,0 +1,15 @@
+name: plex
+services:
+  plex:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      VERSION: ${VERSION}
+    image: lscr.io/linuxserver/plex:1.41.3
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media
+      target: /Media
+      type: bind

--- a/sources/casaos-official/apps/plex/metadata.yaml
+++ b/sources/casaos-official/apps/plex/metadata.yaml
@@ -1,0 +1,30 @@
+architecture: all
+debian_section: video
+description: Stream Movies & TV Shows
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/icon.png
+license: Unknown
+long_description: "Transform your home into a cinematic oasis with your very own media\
+  \ server. Unlike streaming platforms that compress and limit the quality of your\
+  \ content, a Plex server in your home allows you to maintain the pristine, high-bitrate\
+  \ glory of Blu-ray and beyond. Imagine pairing this high-fidelity, uninterrupted\
+  \ media access with cutting-edge home theater tech like VR headsets, 75-inch UHD\
+  \ TVs, or 100-inch laser projectors. The result? A breathtaking visual and auditory\
+  \ experience that streams seamlessly across TVs and mobile devices alike, right\
+  \ from the comfort of your couch. \n\nDeploy Plex on a Zima devices and unlock the\
+  \ ultimate in home entertainment convenience. Enjoy ALMOST limitless storage capacity\
+  \ for your entire media library, lightning-fast local network speeds, and the ability\
+  \ to stream content effortlessly to any device in your home. Experience a world\
+  \ where your favorite shows and movies are always just a click away, stored securely\
+  \ and privately on your own terms.\n"
+maintainer: Plex <auto-converted@casaos.io>
+name: plex
+package_name: casaos-plex-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Plex/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/pocketbase/config.yml
+++ b/sources/casaos-official/apps/pocketbase/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/pocketbase/docker-compose.yml
+++ b/sources/casaos-official/apps/pocketbase/docker-compose.yml
@@ -1,0 +1,12 @@
+name: pocketbase
+services:
+  pocketbase:
+    image: argonptg/pocketbase:0.25.9
+    ports:
+    - protocol: tcp
+      published: 8090
+      target: 8090
+    volumes:
+    - source: /AppData/$AppID/pb_data
+      target: /pb_data
+      type: bind

--- a/sources/casaos-official/apps/pocketbase/metadata.yaml
+++ b/sources/casaos-official/apps/pocketbase/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: devel
+description: Open Source realtime backend in 1 file
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PocketBase/icon.png
+license: Unknown
+long_description: PocketBase is an open-source backend solution that combines a real-time
+  database, authentication, file storage, and an admin dashboard into a single, portable
+  executable.
+maintainer: Gani Georgiev <auto-converted@casaos.io>
+name: pocketbase
+package_name: casaos-pocketbase-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PocketBase/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PocketBase/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PocketBase/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/portainer/config.yml
+++ b/sources/casaos-official/apps/portainer/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/portainer/docker-compose.yml
+++ b/sources/casaos-official/apps/portainer/docker-compose.yml
@@ -1,0 +1,21 @@
+name: portainer
+services:
+  portainer:
+    image: portainer/portainer-ce:2.31.3
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    - protocol: tcp
+      published: 9000
+      target: 9000
+    - protocol: tcp
+      published: 9443
+      target: 9443
+    volumes:
+    - source: /AppData/$AppID
+      target: /data
+      type: bind
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind

--- a/sources/casaos-official/apps/portainer/metadata.yaml
+++ b/sources/casaos-official/apps/portainer/metadata.yaml
@@ -1,0 +1,61 @@
+architecture: all
+debian_section: utils
+description: Lightweight Docker management UI
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Portainer/icon.png
+license: Unknown
+long_description: 'Portainer Community Edition (CE) is a lightweight container management
+  tool offering an intuitive Web interface to simplify building, managing, and monitoring
+  containerized applications. With over 500,000 active users, it is widely appreciated
+  for its ease of use and robust functionality, ideal for individual developers, home
+  lab users, and small teams.
+
+
+  The tool''s core features include multi-platform support, resource management, and
+  real-time monitoring. It supports managing various container platforms, covering
+  containers, images, volumes, and networks. Users can quickly create, deploy, and
+  manage containers via a “smart” graphical interface or comprehensive API, without
+  needing deep command-line expertise. It provides real-time container status monitoring,
+  log viewing, and configuration management, ensuring efficient control over application
+  operations.
+
+
+  Its design philosophy is to “simplify container complexity” with an intuitive interface
+  and default settings that lower the technical barrier. Users can manage containerized
+  applications without complex configurations, saving time and boosting efficiency.
+  It is completely free, with data stored locally, ensuring full user control. Community
+  support via GitHub Discussions and Slack, along with rich documentation and regular
+  updates, enhances the user experience, making it suitable for learning container
+  technology or managing small projects.
+
+
+  **Key Features:**
+
+  - Intuitive Web interface for simplified containerized app management
+
+  - Supports multiple container platforms for unified resource management
+
+  - Real-time monitoring of container status and logs
+
+  - Rapid container deployment and management via API
+
+  - Community support with extensive documentation and assistance
+
+
+  **Learn More:**
+
+  - [Portainer Official Website](https://www.portainer.io/)
+
+  - [Portainer GitHub Repository](https://github.com/portainer/portainer)
+
+  '
+maintainer: Portainer <auto-converted@casaos.io>
+name: portainer
+package_name: casaos-portainer-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Portainer/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Portainer/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/postgresql/config.yml
+++ b/sources/casaos-official/apps/postgresql/config.yml
@@ -1,0 +1,54 @@
+groups:
+- description: null
+  fields:
+  - default: $PUID
+    description: for UserID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PGID
+    description: for GroupID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: specify a timezone to use, see this list.
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: Postgres server username
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: casaos
+    description: Postgres server password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: casaos
+    description: Specify the name of a database to be created on image startup.
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/postgresql/docker-compose.yml
+++ b/sources/casaos-official/apps/postgresql/docker-compose.yml
@@ -1,0 +1,19 @@
+name: postgresql
+services:
+  postgresql:
+    environment:
+      PGID: ${PGID}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: postgres:17.4
+    ports:
+    - protocol: tcp
+      published: 5432
+      target: 5432
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/data
+      target: /var/lib/postgresql/data
+      type: bind

--- a/sources/casaos-official/apps/postgresql/metadata.yaml
+++ b/sources/casaos-official/apps/postgresql/metadata.yaml
@@ -1,0 +1,32 @@
+architecture: all
+debian_section: devel
+description: PostgreSQL is an advanced, enterprise-class, and open-source relational...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PostgreSQL/icon.png
+license: Unknown
+long_description: 'PostgreSQL is an advanced, enterprise-class, and open-source relational
+  database system. PostgreSQL supports both SQL (relational) and JSON (non-relational)
+  querying.
+
+
+  PostgreSQL is a powerful, open source object-relational database system with over
+  35 years of active development that has earned it a strong reputation for reliability,
+  feature robustness, and performance.
+
+
+  PostgreSQL is a highly stable database backed by more than 20 years of development
+  by the open-source community.
+
+
+  PostgreSQL is used as a primary database for many web applications as well as mobile
+  and analytics applications.
+
+  '
+maintainer: PostgreSQL Global Dev't Group <auto-converted@casaos.io>
+name: postgresql
+package_name: casaos-postgresql-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/prowlarr/config.yml
+++ b/sources/casaos-official/apps/prowlarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/prowlarr/docker-compose.yml
+++ b/sources/casaos-official/apps/prowlarr/docker-compose.yml
@@ -1,0 +1,16 @@
+name: prowlarr
+services:
+  prowlarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/prowlarr:1.37.0
+    ports:
+    - protocol: tcp
+      published: 9696
+      target: 9696
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/prowlarr/metadata.yaml
+++ b/sources/casaos-official/apps/prowlarr/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: misc
+description: Integration of various PVR applications
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Prowlarr/icon.png
+license: Unknown
+long_description: Prowlarr is an indexer manager/proxy built on the popular *arr .net/reactjs
+  base stack to integrate with your various PVR apps. Prowlarr supports management
+  of both Torrent Trackers and Usenet Indexers. It integrates seamlessly with Lidarr,
+  Mylar3, Radarr, Readarr, and Sonarr offering complete management of your indexers
+  with no per app Indexer setup required (we do it all).
+maintainer: Prowlarr Team <auto-converted@casaos.io>
+name: prowlarr
+package_name: casaos-prowlarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Prowlarr/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Prowlarr/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/pyload/config.yml
+++ b/sources/casaos-official/apps/pyload/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run PyLoad as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run PyLoad as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/pyload/docker-compose.yml
+++ b/sources/casaos-official/apps/pyload/docker-compose.yml
@@ -1,0 +1,22 @@
+name: pyload
+services:
+  pyload:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/pyload-ng:0.5.0
+    ports:
+    - protocol: tcp
+      published: 8000
+      target: 8000
+    - protocol: tcp
+      published: 9666
+      target: 9666
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/pyload/metadata.yaml
+++ b/sources/casaos-official/apps/pyload/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: misc
+description: Free Downloader Manager.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PyLoad/icon.png
+license: Unknown
+long_description: pyLoad is a Free and Open Source download manager written in Python
+  and designed to be extremely lightweight, easily extensible and fully manageable
+  via web.
+maintainer: linuxserver <auto-converted@casaos.io>
+name: pyload
+package_name: casaos-pyload-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PyLoad/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PyLoad/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/PyLoad/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/qbittorrent/config.yml
+++ b/sources/casaos-official/apps/qbittorrent/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run qBittorrent as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run qBittorrent as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: '002'
+    description: Run qBittorrent as specified UMASK.
+    id: UMASK
+    label: UMASK
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/qbittorrent/docker-compose.yml
+++ b/sources/casaos-official/apps/qbittorrent/docker-compose.yml
@@ -1,0 +1,20 @@
+name: qbittorrent
+services:
+  qbittorrent:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+      UMASK: ${UMASK}
+    image: ghcr.io/hotio/qbittorrent:release-5.0.4
+    ports:
+    - protocol: tcp
+      published: 8181
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /DATA
+      type: bind

--- a/sources/casaos-official/apps/qbittorrent/metadata.yaml
+++ b/sources/casaos-official/apps/qbittorrent/metadata.yaml
@@ -1,0 +1,39 @@
+architecture: all
+debian_section: misc
+description: P2P bittorrent download
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/qBittorrent/icon.png
+license: Unknown
+long_description: '**Elevate Your Home Media Experience**. qBittorrent transforms
+  your home media setup with a polished interface reminiscent of µTorrent, minus the
+  ads. Unlike traditional download tools, it offers a streamlined, efficient, and
+  ad-free experience. This makes it a perfect fit for those seeking a hassle-free
+  way to manage and enjoy their media collections at home.
+
+
+  **Feature-Rich and User-Friendly**. With qBittorrent, you gain access to a well-integrated
+  and extensible search engine, allowing simultaneous searches across multiple torrent
+  sites, and category-specific searches for books, music, and software. Its support
+  for RSS feeds with advanced filters, magnet links, encrypted connections, and more,
+  ensures you have complete control over your downloads. Available on all major platforms
+  and in around 70 languages, qBittorrent is both versatile and accessible.
+
+
+  **Seamless Integration with Private Clouds like Zima**. Deploying qBittorrent on
+  private cloud devices such as Zima offers unparalleled convenience. Enjoy virtually
+  unlimited storage, enhanced privacy for your data, and local network speeds that
+  make downloading and streaming effortless. This setup ensures that your media library
+  is always at your fingertips, securely and swiftly.
+
+  '
+maintainer: qBittorrent <auto-converted@casaos.io>
+name: qbittorrent
+package_name: casaos-qbittorrent-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/qBittorrent/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/qBittorrent/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/qBittorrent/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/radarr/config.yml
+++ b/sources/casaos-official/apps/radarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Radarr as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Radarr as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/radarr/docker-compose.yml
+++ b/sources/casaos-official/apps/radarr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: radarr
+services:
+  radarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/radarr:5.26.2
+    ports:
+    - protocol: tcp
+      published: 7878
+      target: 7878
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/Movies
+      target: /movies
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/radarr/metadata.yaml
+++ b/sources/casaos-official/apps/radarr/metadata.yaml
@@ -1,0 +1,26 @@
+architecture: all
+debian_section: video
+description: The movie collection manager for Usenet and BitTorrent users
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/icon.png
+license: Unknown
+long_description: Radarr is a movie collection manager for Usenet and BitTorrent users.
+  It can monitor multiple RSS feeds for new movies and will interface with clients
+  and indexers to grab, sort, and rename them. It can also be configured to automatically
+  upgrade the quality of existing files in the library when a better quality format
+  becomes available. Note that only one type of a given movie is supported. If you
+  want both an 4k version and 1080p version of a given movie you will need multiple
+  instances.
+maintainer: Radarr <auto-converted@casaos.io>
+name: radarr
+package_name: casaos-radarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/screenshot-4.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Radarr/screenshot-5.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ragflow/config.yml
+++ b/sources/casaos-official/apps/ragflow/config.yml
@@ -1,0 +1,288 @@
+groups:
+- description: null
+  fields:
+  - default: ragflow-es01
+    description: Elasticsearch Host
+    id: ES_HOST
+    label: ES_HOST
+    required: false
+    type: string
+  - default: ragflow-infinity
+    description: Infinity Host
+    id: INFINITY_HOST
+    label: INFINITY_HOST
+    required: false
+    type: string
+  - default: ragflow-minio
+    description: MinIO Host
+    id: MINIO_HOST
+    label: MINIO_HOST
+    required: false
+    type: string
+  - default: ragflow-mysql
+    description: MySQL Host
+    id: MYSQL_HOST
+    label: MYSQL_HOST
+    required: false
+    type: string
+  - default: ragflow-opensearch01
+    description: OpenSearch Host
+    id: OS_HOST
+    label: OS_HOST
+    required: false
+    type: string
+  - default: ragflow-redis
+    description: Redis Host
+    id: REDIS_HOST
+    label: REDIS_HOST
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $TZ
+    description: Zeitzone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: infini_rag_flow
+    description: Elasticsearch-Passwort
+    id: ELASTIC_PASSWORD
+    label: ELASTIC_PASSWORD
+    required: false
+    type: password
+  - default: infini_rag_flow
+    description: MinIO Root Passwort
+    id: MINIO_ROOT_PASSWORD
+    label: MINIO_ROOT_PASSWORD
+    required: false
+    type: password
+  - default: rag_flow
+    description: MinIO Root Benutzer
+    id: MINIO_ROOT_USER
+    label: MINIO_ROOT_USER
+    required: false
+    type: string
+  - default: infini_rag_flow
+    description: MySQL Benutzerpasswort
+    id: MYSQL_PASSWORD
+    label: MYSQL_PASSWORD
+    required: false
+    type: password
+  - default: mysql
+    description: MySQL Root Passwort
+    id: MYSQL_ROOT_PASSWORD
+    label: MYSQL_ROOT_PASSWORD
+    required: false
+    type: password
+  - default: infini_rag_flow_OS_01
+    description: Initiales OpenSearch-Administratorpasswort
+    id: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    label: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    required: false
+    type: password
+  - default: infini_rag_flow_OS_01
+    description: OpenSearch-Passwort
+    id: OPENSEARCH_PASSWORD
+    label: OPENSEARCH_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: 'false'
+    description: ''
+    id: BOOTSTRAP_MEMORY_LOCK
+    label: bootstrap.memory_lock
+    required: false
+    type: string
+  - default: 2gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE
+    label: cluster.routing.allocation.disk.watermark.flood_stage
+    required: false
+    type: string
+  - default: 3gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH
+    label: cluster.routing.allocation.disk.watermark.high
+    required: false
+    type: string
+  - default: 5gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW
+    label: cluster.routing.allocation.disk.watermark.low
+    required: false
+    type: string
+  - default: single-node
+    description: Discovery-Typ
+    id: DISCOVERY_TYPE
+    label: discovery.type
+    required: false
+    type: string
+  - default: es01
+    description: Knotenname
+    id: NODE_NAME
+    label: node.name
+    required: false
+    type: string
+  - default: 'true'
+    description: X-Pack-Sicherheit aktivieren
+    id: XPACK_SECURITY_ENABLED
+    label: xpack.security.enabled
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: XPACK_SECURITY_HTTP_SSL_ENABLED
+    label: xpack.security.http.ssl.enabled
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: XPACK_SECURITY_TRANSPORT_SSL_ENABLED
+    label: xpack.security.transport.ssl.enabled
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: BOOTSTRAP_MEMORY_LOCK
+    label: bootstrap.memory_lock
+    required: false
+    type: string
+  - default: 2gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE
+    label: cluster.routing.allocation.disk.watermark.flood_stage
+    required: false
+    type: string
+  - default: 3gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH
+    label: cluster.routing.allocation.disk.watermark.high
+    required: false
+    type: string
+  - default: 5gb
+    description: ''
+    id: CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW
+    label: cluster.routing.allocation.disk.watermark.low
+    required: false
+    type: string
+  - default: single-node
+    description: Discovery-Typ
+    id: DISCOVERY_TYPE
+    label: discovery.type
+    required: false
+    type: string
+  - default: '9201'
+    description: HTTP-Port
+    id: HTTP_PORT
+    label: http.port
+    required: false
+    type: string
+  - default: opensearch01
+    description: Knotenname
+    id: NODE_NAME
+    label: node.name
+    required: false
+    type: string
+  - default: 'false'
+    description: Plugin-Sicherheit deaktivieren
+    id: PLUGINS_SECURITY_DISABLED
+    label: plugins.security.disabled
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: PLUGINS_SECURITY_SSL_HTTP_ENABLED
+    label: plugins.security.ssl.http.enabled
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: PLUGINS_SECURITY_SSL_TRANSPORT_ENABLED
+    label: plugins.security.ssl.transport.enabled
+    required: false
+    type: string
+  - default: infiniflow/sandbox-base-nodejs:latest
+    description: Sandbox Base NodeJS Image
+    id: SANDBOX_BASE_NODEJS_IMAGE
+    label: SANDBOX_BASE_NODEJS_IMAGE
+    required: false
+    type: string
+  - default: infiniflow/sandbox-base-python:latest
+    description: Sandbox Base Python Image
+    id: SANDBOX_BASE_PYTHON_IMAGE
+    label: SANDBOX_BASE_PYTHON_IMAGE
+    required: false
+    type: string
+  - default: 'false'
+    description: Seccomp aktivieren
+    id: SANDBOX_ENABLE_SECCOMP
+    label: SANDBOX_ENABLE_SECCOMP
+    required: false
+    type: string
+  - default: '3'
+    description: Sandbox Executor Manager Pool Größe
+    id: SANDBOX_EXECUTOR_MANAGER_POOL_SIZE
+    label: SANDBOX_EXECUTOR_MANAGER_POOL_SIZE
+    required: false
+    type: integer
+  - default: 256m
+    description: Sandbox Max Speicher
+    id: SANDBOX_MAX_MEMORY
+    label: SANDBOX_MAX_MEMORY
+    required: false
+    type: string
+  - default: 10s
+    description: Sandbox Timeout
+    id: SANDBOX_TIMEOUT
+    label: SANDBOX_TIMEOUT
+    required: false
+    type: integer
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/ragflow/docker-compose.yml
+++ b/sources/casaos-official/apps/ragflow/docker-compose.yml
@@ -1,0 +1,181 @@
+name: ragflow
+services:
+  ragflow:
+    environment:
+      ES_HOST: ${ES_HOST}
+      INFINITY_HOST: ${INFINITY_HOST}
+      MINIO_HOST: ${MINIO_HOST}
+      MYSQL_HOST: ${MYSQL_HOST}
+      OS_HOST: ${OS_HOST}
+      REDIS_HOST: ${REDIS_HOST}
+      TZ: ${TZ}
+    image: icewhaletech/ragflow:v0.21.1
+    ports:
+    - protocol: tcp
+      published: 9380
+      target: 9380
+    - protocol: tcp
+      published: 30080
+      target: 80
+    - protocol: tcp
+      published: 10443
+      target: 443
+    - protocol: tcp
+      published: 5678
+      target: 5678
+    - protocol: tcp
+      published: 5679
+      target: 5679
+    - protocol: tcp
+      published: 9382
+      target: 9382
+    volumes:
+    - source: /AppData/$AppID/ragflow-logs
+      target: /ragflow/logs
+      type: bind
+    - source: /AppData/$AppID/history_data_agent
+      target: /ragflow/history_data_agent
+      type: bind
+  ragflow-es01:
+    environment:
+      BOOTSTRAP_MEMORY_LOCK: ${BOOTSTRAP_MEMORY_LOCK}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW}
+      DISCOVERY_TYPE: ${DISCOVERY_TYPE}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
+      NODE_NAME: ${NODE_NAME}
+      TZ: ${TZ}
+      XPACK_SECURITY_ENABLED: ${XPACK_SECURITY_ENABLED}
+      XPACK_SECURITY_HTTP_SSL_ENABLED: ${XPACK_SECURITY_HTTP_SSL_ENABLED}
+      XPACK_SECURITY_TRANSPORT_SSL_ENABLED: ${XPACK_SECURITY_TRANSPORT_SSL_ENABLED}
+    image: elasticsearch:8.11.3
+    ports:
+    - protocol: tcp
+      published: 9200
+      target: 9200
+    volumes:
+    - source: /AppData/$AppID/es01
+      target: /usr/share/elasticsearch/data
+      type: bind
+  ragflow-infinity:
+    environment:
+      TZ: ${TZ}
+    image: icewhaletech/ragflow-infinity:v0.6.1
+    ports:
+    - protocol: tcp
+      published: 23817
+      target: 23817
+    - protocol: tcp
+      published: 23820
+      target: 23820
+    - protocol: tcp
+      published: 15432
+      target: 5432
+    volumes:
+    - source: /AppData/$AppID/infinity
+      target: /var/infinity
+      type: bind
+  ragflow-minio:
+    command:
+    - server
+    - --console-address
+    - :9001
+    - /data
+    environment:
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      TZ: ${TZ}
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
+    ports:
+    - protocol: tcp
+      published: 9000
+      target: 9000
+    - protocol: tcp
+      published: 9001
+      target: 9001
+    volumes:
+    - source: /AppData/$AppID/minio
+      target: /data
+      type: bind
+  ragflow-mysql:
+    command:
+    - --max_connections=1000
+    - --character-set-server=utf8mb4
+    - --collation-server=utf8mb4_unicode_ci
+    - --default-authentication-plugin=mysql_native_password
+    - --tls_version=TLSv1.2,TLSv1.3
+    - --binlog_expire_logs_seconds=604800
+    environment:
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      TZ: ${TZ}
+    image: icewhaletech/ragflow-mysql:8.0.39
+    ports:
+    - protocol: tcp
+      published: 5455
+      target: 3306
+    volumes:
+    - source: /AppData/$AppID/mysql
+      target: /var/lib/mysql
+      type: bind
+  ragflow-opensearch01:
+    environment:
+      BOOTSTRAP_MEMORY_LOCK: ${BOOTSTRAP_MEMORY_LOCK}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_FLOOD_STAGE}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH}
+      CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW: ${CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW}
+      DISCOVERY_TYPE: ${DISCOVERY_TYPE}
+      HTTP_PORT: ${HTTP_PORT}
+      NODE_NAME: ${NODE_NAME}
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
+      OPENSEARCH_PASSWORD: ${OPENSEARCH_PASSWORD}
+      PLUGINS_SECURITY_DISABLED: ${PLUGINS_SECURITY_DISABLED}
+      PLUGINS_SECURITY_SSL_HTTP_ENABLED: ${PLUGINS_SECURITY_SSL_HTTP_ENABLED}
+      PLUGINS_SECURITY_SSL_TRANSPORT_ENABLED: ${PLUGINS_SECURITY_SSL_TRANSPORT_ENABLED}
+      TZ: ${TZ}
+    image: hub.icert.top/opensearchproject/opensearch:2.19.1
+    ports:
+    - protocol: tcp
+      published: 9201
+      target: 9201
+    volumes:
+    - source: /AppData/$AppID/opensearch01
+      target: /usr/share/opensearch/data
+      type: bind
+  ragflow-redis:
+    command:
+    - redis-server
+    - --requirepass
+    - infini_rag_flow
+    - --maxmemory
+    - 128mb
+    - --maxmemory-policy
+    - allkeys-lru
+    image: valkey/valkey:8
+    ports:
+    - protocol: tcp
+      published: 6379
+      target: 6379
+    volumes:
+    - source: /AppData/$AppID/redis
+      target: /data
+      type: bind
+  ragflow-sandbox-executor-manager:
+    environment:
+      SANDBOX_BASE_NODEJS_IMAGE: ${SANDBOX_BASE_NODEJS_IMAGE}
+      SANDBOX_BASE_PYTHON_IMAGE: ${SANDBOX_BASE_PYTHON_IMAGE}
+      SANDBOX_ENABLE_SECCOMP: ${SANDBOX_ENABLE_SECCOMP}
+      SANDBOX_EXECUTOR_MANAGER_POOL_SIZE: ${SANDBOX_EXECUTOR_MANAGER_POOL_SIZE}
+      SANDBOX_MAX_MEMORY: ${SANDBOX_MAX_MEMORY}
+      SANDBOX_TIMEOUT: ${SANDBOX_TIMEOUT}
+      TZ: ${TZ}
+    image: infiniflow/sandbox-executor-manager:latest
+    ports:
+    - protocol: tcp
+      published: 9385
+      target: 9385
+    volumes:
+    - source: /var/run/docker.sock
+      target: /var/run/docker.sock
+      type: bind

--- a/sources/casaos-official/apps/ragflow/metadata.yaml
+++ b/sources/casaos-official/apps/ragflow/metadata.yaml
@@ -1,0 +1,61 @@
+architecture: all
+debian_section: misc
+description: RagFlow ist eine Open-Source-RAG-Engine, die auf tiefem...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RagFlow/icon.png
+license: Unknown
+long_description: 'RagFlow ist eine Open-Source-RAG-Engine, die auf tiefem Dokumentenverständnis
+  basiert.
+
+
+  RagFlow ist eine Open-Source-RAG-Engine (Retrieval-Augmented Generation), die auf
+  tiefem Dokumentenverständnis basiert. Sie ermöglicht es Benutzern, ihr eigenes privates
+  ChatGPT zu erstellen, indem sie die Leistungsfähigkeit großer Sprachmodelle und
+  tiefgreifender Dokumentenanalysefähigkeiten nutzt. RagFlow unterstützt verschiedene
+  Dokumentformate, einschließlich PDF, Word, Markdown und mehr, und ermöglicht es
+  Benutzern, intelligente Frage-Antwort-Systeme auf der Grundlage ihrer eigenen Dokumente
+  zu erstellen.
+
+
+  **Hauptfunktionen:**
+
+  - Tiefes Dokumentenverständnis mit erweiterten Analysefähigkeiten
+
+  - Unterstützung für mehrere Dokumentformate (PDF, Word, Markdown, etc.)
+
+  - Private Wissensdatenbank mit Datensicherheitsgarantie
+
+  - Anpassbare RAG-Workflows für verschiedene Anwendungsfälle
+
+  - Integration mit beliebten großen Sprachmodellen
+
+  - Webbasierte Oberfläche für einfache Verwaltung und Interaktion
+
+
+  **Hardware-Anforderungen:**
+
+  - CPU >= 4 Kerne
+
+  - RAM >= 16 GB
+
+  - Festplatte >= 50 GB
+
+
+  **Mehr Erfahren:**
+
+  - [RagFlow Offizielle Website](https://ragflow.io)
+
+  - [RagFlow GitHub Repository](https://github.com/infiniflow/ragflow)
+
+  '
+maintainer: RagFlow <auto-converted@casaos.io>
+name: ragflow
+package_name: casaos-ragflow-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RagFlow/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RagFlow/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RagFlow/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/rdtclient/config.yml
+++ b/sources/casaos-official/apps/rdtclient/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: '002'
+    description: ''
+    id: UMASK
+    label: UMASK
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/rdtclient/docker-compose.yml
+++ b/sources/casaos-official/apps/rdtclient/docker-compose.yml
@@ -1,0 +1,20 @@
+name: rdtclient
+services:
+  rdtclient:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+      UMASK: ${UMASK}
+    image: rogerfar/rdtclient:2
+    ports:
+    - protocol: tcp
+      published: 6500
+      target: 6500
+    volumes:
+    - source: /Downloads
+      target: /data/downloads
+      type: bind
+    - source: /AppData/$AppID/db
+      target: /data/db
+      type: bind

--- a/sources/casaos-official/apps/rdtclient/metadata.yaml
+++ b/sources/casaos-official/apps/rdtclient/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: misc
+description: CasaOS Container App for rdtclient
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RDTClient/icon.png
+license: Unknown
+long_description: CasaOS Container App for rdtclient
+maintainer: Unknown <auto-converted@casaos.io>
+name: rdtclient
+package_name: casaos-rdtclient-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RDTClient/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/readarr/config.yml
+++ b/sources/casaos-official/apps/readarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Readarr as specified GID
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Readarr as specified UID
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: Timezon
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/readarr/docker-compose.yml
+++ b/sources/casaos-official/apps/readarr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: readarr
+services:
+  readarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/readarr:0.3.10-develop
+    ports:
+    - protocol: tcp
+      published: 8787
+      target: 8787
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/Books
+      target: /books
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/readarr/metadata.yaml
+++ b/sources/casaos-official/apps/readarr/metadata.yaml
@@ -1,0 +1,21 @@
+architecture: all
+debian_section: video
+description: Ebook and audiobook collection manager for Usenet and BitTorrent users.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Readarr/icon.png
+license: Unknown
+long_description: Readarr is a ebook collection manager for Usenet and BitTorrent
+  users. It can monitor multiple RSS feeds for new books from your favorite authors
+  and will interface with clients and indexers to grab, sort, and rename them.
+maintainer: Readarr Team <auto-converted@casaos.io>
+name: readarr
+package_name: casaos-readarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Readarr/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Readarr/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Readarr/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Readarr/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/resilio-sync/config.yml
+++ b/sources/casaos-official/apps/resilio-sync/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/resilio-sync/docker-compose.yml
+++ b/sources/casaos-official/apps/resilio-sync/docker-compose.yml
@@ -1,0 +1,25 @@
+name: resilio-sync
+services:
+  resilio-sync:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/resilio-sync:2.7.3
+    ports:
+    - protocol: tcp
+      published: 55555
+      target: 55555
+    - protocol: tcp
+      published: 8888
+      target: 8888
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /sync
+      type: bind
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/resilio-sync/metadata.yaml
+++ b/sources/casaos-official/apps/resilio-sync/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: misc
+description: Unleash the power of seamless file synchronization.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Resilio-sync/icon.png
+license: Unknown
+long_description: resilio-sync is a Docker-based application that enables fast and
+  secure file synchronization and sharing.
+maintainer: Unknown <auto-converted@casaos.io>
+name: resilio-sync
+package_name: casaos-resilio-sync-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Resilio-sync/screenshot-1.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/retroarch/config.yml
+++ b/sources/casaos-official/apps/retroarch/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: '"/var/www/html"'
+    description: ROOT_WWW_PATH
+    id: ROOT_WWW_PATH
+    label: ROOT_WWW_PATH
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/retroarch/docker-compose.yml
+++ b/sources/casaos-official/apps/retroarch/docker-compose.yml
@@ -1,0 +1,10 @@
+name: retroarch
+services:
+  retroarch:
+    environment:
+      ROOT_WWW_PATH: ${ROOT_WWW_PATH}
+    image: inglebard/retroarch-web:latest
+    ports:
+    - protocol: tcp
+      published: 8183
+      target: 80

--- a/sources/casaos-official/apps/retroarch/metadata.yaml
+++ b/sources/casaos-official/apps/retroarch/metadata.yaml
@@ -1,0 +1,67 @@
+architecture: all
+debian_section: games
+description: Online retro games emulator
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RetroArch/icon.png
+license: Unknown
+long_description: 'RetroArch-web is a web-based classic game emulator that enables
+  users to enjoy a wide range of retro games directly in modern browsers. Supporting
+  platforms like GBA, N64, DOS games, and NES (FC), it brings nostalgic gaming to
+  life. Built on the open-source RetroArch project, RetroArch-web delivers robust
+  features, including high-quality graphics rendering, audio processing, input controls,
+  and save/load game progress, ensuring a precise and smooth emulation experience.
+
+
+  Designed for ease of use, RetroArch-web requires no complex software installation,
+  running seamlessly in browsers. Its flexible configuration options let users customize
+  controller setups, visual filters, and audio settings to suit individual preferences.
+  With broad cross-platform compatibility, it ensures stable performance across devices,
+  offering retro gaming enthusiasts a consistent experience on the go.
+
+
+  Backed by an active open-source community, RetroArch-web continually improves performance
+  and expands supported game platforms. Whether revisiting classic arcade titles or
+  exploring vintage console games, RetroArch-web stands out as the ideal choice for
+  retro gamers, combining powerful emulation with a user-friendly interface.
+
+
+  **Key Features:**
+
+  - Polished interface for browsing game collections with thumbnails and animated
+  backgrounds
+
+  - Supports multiple emulators and game engines for running classic games and discs
+
+  - Next-frame response time for near-native hardware low-latency experience
+
+  - Highly configurable settings to tweak game performance and display options
+
+  - Automatic controller configuration for easy multiplayer gaming
+
+  - Shaders to enhance old game rendering and mimic CRT monitor effects
+
+  - Netplay for multiplayer gaming and spectator mode
+
+  - Achievements system to unlock trophies and badges in classic games
+
+  - Recording and streaming for capturing gameplay or live streaming
+
+
+  **Learn More:**
+
+  - [RetroArch Official Website](https://www.retroarch.com)
+
+  - [RetroArch GitHub Repository](https://github.com/libretro/RetroArch)
+
+  '
+maintainer: inglebard <auto-converted@casaos.io>
+name: retroarch
+package_name: casaos-retroarch-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RetroArch/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RetroArch/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RetroArch/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/romm/config.yml
+++ b/sources/casaos-official/apps/romm/config.yml
@@ -1,0 +1,99 @@
+groups:
+- description: null
+  fields:
+  - default: romm-db
+    description: Database Host
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: romm
+    description: Database Name
+    id: DB_NAME
+    label: DB_NAME
+    required: false
+    type: string
+  - default: '""'
+    description: IGDB Client ID
+    id: IGDB_CLIENT_ID
+    label: IGDB_CLIENT_ID
+    required: false
+    type: string
+  - default: romm
+    description: Database Name
+    id: MARIADB_DATABASE
+    label: MARIADB_DATABASE
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: romm-user
+    description: Database User
+    id: DB_USER
+    label: DB_USER
+    required: false
+    type: string
+  - default: casaos
+    description: Database Password
+    id: DB_PASSWD
+    label: DB_PASSWD
+    required: false
+    type: password
+  - default: '""'
+    description: 'Authentication Secret Key: Generate a key with `openssl rand -hex
+      32`'
+    id: ROMM_AUTH_SECRET_KEY
+    label: ROMM_AUTH_SECRET_KEY
+    required: false
+    type: password
+  - default: '""'
+    description: 'IGDB Client Secret: https://api-docs.igdb.com/#account-creation'
+    id: IGDB_CLIENT_SECRET
+    label: IGDB_CLIENT_SECRET
+    required: false
+    type: password
+  - default: '""'
+    description: ScreenScraper Username
+    id: SCREENSCRAPER_USER
+    label: SCREENSCRAPER_USER
+    required: false
+    type: string
+  - default: '""'
+    description: 'ScreenScraper Password: https://docs.romm.app/latest/Getting-Started/Metadata-Providers/#screenscraper'
+    id: SCREENSCRAPER_PASSWORD
+    label: SCREENSCRAPER_PASSWORD
+    required: false
+    type: password
+  - default: '""'
+    description: 'SteamGridDB API Key: https://github.com/rommapp/romm/wiki/Generate-API-Keys#steamgriddb'
+    id: STEAMGRIDDB_API_KEY
+    label: STEAMGRIDDB_API_KEY
+    required: false
+    type: password
+  - default: casaos
+    description: Root Password
+    id: MARIADB_ROOT_PASSWORD
+    label: MARIADB_ROOT_PASSWORD
+    required: false
+    type: password
+  - default: romm-user
+    description: Database User
+    id: MARIADB_USER
+    label: MARIADB_USER
+    required: false
+    type: string
+  - default: casaos
+    description: Database Password
+    id: MARIADB_PASSWORD
+    label: MARIADB_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/romm/docker-compose.yml
+++ b/sources/casaos-official/apps/romm/docker-compose.yml
@@ -1,0 +1,46 @@
+name: romm
+services:
+  romm:
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_NAME: ${DB_NAME}
+      DB_PASSWD: ${DB_PASSWD}
+      DB_USER: ${DB_USER}
+      IGDB_CLIENT_ID: ${IGDB_CLIENT_ID}
+      IGDB_CLIENT_SECRET: ${IGDB_CLIENT_SECRET}
+      ROMM_AUTH_SECRET_KEY: ${ROMM_AUTH_SECRET_KEY}
+      SCREENSCRAPER_PASSWORD: ${SCREENSCRAPER_PASSWORD}
+      SCREENSCRAPER_USER: ${SCREENSCRAPER_USER}
+      STEAMGRIDDB_API_KEY: ${STEAMGRIDDB_API_KEY}
+    image: rommapp/romm:4.0.1
+    ports:
+    - protocol: tcp
+      published: 8285
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/resources
+      target: /romm/resources
+      type: bind
+    - source: /AppData/$AppID/redis-data
+      target: /redis-data
+      type: bind
+    - source: /AppData/$AppID/library
+      target: /romm/library
+      type: bind
+    - source: /AppData/$AppID/assets
+      target: /romm/assets
+      type: bind
+    - source: /AppData/$AppID/config
+      target: /romm/config
+      type: bind
+  romm-db:
+    environment:
+      MARIADB_DATABASE: ${MARIADB_DATABASE}
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD}
+      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
+      MARIADB_USER: ${MARIADB_USER}
+    image: mariadb:11.8.2
+    volumes:
+    - source: /AppData/$AppID/mysql
+      target: /var/lib/mysql
+      type: bind

--- a/sources/casaos-official/apps/romm/metadata.yaml
+++ b/sources/casaos-official/apps/romm/metadata.yaml
@@ -1,0 +1,75 @@
+architecture: all
+debian_section: games
+description: RomM is a self-hosted ROM manager for managing and playing game collections.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/icon.png
+license: Unknown
+long_description: 'RomM is a self-hosted game collection management app designed for
+  emulator enthusiasts, offering a convenient way to scan, enrich, browse, and play
+  games. Its responsive Web interface allows users to manage collections via any modern
+  browser, supporting over 400 platforms, ideal for retro gaming fans building personal
+  game libraries.
+
+
+  The app''s core features include robust library management and seamless gameplay.
+  It fetches metadata from IGDB, Screenscraper, and MobyGames, and custom artwork
+  from SteamGridDB, enhancing the visual appeal of collections. Users can play games
+  directly in the browser using EmulatorJS and RuffleRS, with support for multi-disk
+  games, DLCs, patches, and manuals. It also enables parsing and filtering by filename
+  tags for tailored organization. Additionally, it supports multi-user accounts with
+  limited access permissions, allowing library sharing with friends and displaying
+  RetroAchievements.
+
+
+  It can be flexibly deployed on personal servers or NAS devices, with official apps
+  for Playnite and muOS enhancing cross-device access. Users can upload, update, or
+  delete games via the Web interface, with community support documentation expanding
+  functionality. Whether managing a personal retro game library or sharing with others,
+  the app''s intuitive interface and high customizability deliver a modern game management
+  platform, meeting diverse needs.
+
+
+  **Key Features:**
+
+  - Scan and enhance your game library with metadata from IGDB, Screenscraper and
+  MobyGames
+
+  - Fetch custom artwork from SteamGridDB
+
+  - Display your achievements from Retroachievements
+
+  - Metadata available for 400+ platforms
+
+  - Play games directly from the browser using EmulatorJS and RuffleRS
+
+  - Share your library with friends with limited access and permissions
+
+  - Official apps for Playnite and muOS
+
+  - Supports multi-disk games, DLCs, mods, hacks, patches, and manuals
+
+  - Parse and filter by tags in filenames
+
+  - View, upload, update, and delete games from any modern web browser
+
+
+  **Learn More:**
+
+  - [RomM Official Website](https://romm.app)
+
+  - [RomM GitHub Repository](https://github.com/rommapp/romm)
+
+  '
+maintainer: rommapp <auto-converted@casaos.io>
+name: romm
+package_name: casaos-romm-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/RomM/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/sabnzbd/config.yml
+++ b/sources/casaos-official/apps/sabnzbd/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/sabnzbd/docker-compose.yml
+++ b/sources/casaos-official/apps/sabnzbd/docker-compose.yml
@@ -1,0 +1,22 @@
+name: sabnzbd
+services:
+  sabnzbd:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/sabnzbd:4.1.0
+    ports:
+    - protocol: tcp
+      published: 8282
+      target: 8080
+    volumes:
+    - source: /Downloads
+      target: /incomplete-downloads
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/sabnzbd/metadata.yaml
+++ b/sources/casaos-official/apps/sabnzbd/metadata.yaml
@@ -1,0 +1,27 @@
+architecture: all
+debian_section: video
+description: Free and easy binary newsreader
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/icon.png
+license: Unknown
+long_description: SABnzbd is an Open Source Binary Newsreader written in Python. It's
+  totally free, easy to use, and works practically everywhere. SABnzbd makes Usenet
+  as simple and streamlined as possible by automating everything we can. All you have
+  to do is add an .nzb. SABnzbd takes over from there, where it will be automatically
+  downloaded, verified, repaired, extracted and filed away with zero human interaction.
+  SABnzbd offers an easy setup wizard and has self-analysis tools to verify your setup.
+maintainer: Sabnzbd Team <auto-converted@casaos.io>
+name: sabnzbd
+package_name: casaos-sabnzbd-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-6.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sabnzbd/screenshot-7.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/sickchill/config.yml
+++ b/sources/casaos-official/apps/sickchill/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/sickchill/docker-compose.yml
+++ b/sources/casaos-official/apps/sickchill/docker-compose.yml
@@ -1,0 +1,22 @@
+name: sickchill
+services:
+  sickchill:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/sickchill:2023.6.27
+    ports:
+    - protocol: tcp
+      published: 8081
+      target: 8081
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind
+    - source: /Media/TV Shows
+      target: /tv
+      type: bind

--- a/sources/casaos-official/apps/sickchill/metadata.yaml
+++ b/sources/casaos-official/apps/sickchill/metadata.yaml
@@ -1,0 +1,26 @@
+architecture: all
+debian_section: video
+description: Automatic video library manager for TV Shows
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/icon.png
+license: Unknown
+long_description: 'SickChill is an automatic Video Library Manager for TV Shows. It
+  watches for new episodes of your favorite shows, and when they are posted it does
+  its magic: automatic torrent/nzb searching, downloading, and processing at the qualities
+  you want.
+
+  '
+maintainer: Sickchill Team <auto-converted@casaos.io>
+name: sickchill
+package_name: casaos-sickchill-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-5.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sickchill/screenshot-6.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/siyuan-note/config.yml
+++ b/sources/casaos-official/apps/siyuan-note/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/siyuan-note/docker-compose.yml
+++ b/sources/casaos-official/apps/siyuan-note/docker-compose.yml
@@ -1,0 +1,17 @@
+name: siyuan-note
+services:
+  siyuan-note:
+    command:
+    - --accessAuthCode=casaos --workspace=/siyuan/workspace/
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+    image: b3log/siyuan:v3.0.1
+    ports:
+    - protocol: tcp
+      published: 6806
+      target: 6806
+    volumes:
+    - source: /AppData/$AppID/workspace
+      target: /siyuan/workspace
+      type: bind

--- a/sources/casaos-official/apps/siyuan-note/metadata.yaml
+++ b/sources/casaos-official/apps/siyuan-note/metadata.yaml
@@ -1,0 +1,45 @@
+architecture: all
+debian_section: text
+description: Private personal knowledge management
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Siyuan-Note/icon.png
+license: Unknown
+long_description: 'Experience Seamless Knowledge Management with SiYuan. SiYuan redefines
+  knowledge management by seamlessly integrating with your home TV, mobile devices,
+  and other platforms. Unlike traditional knowledge systems, SiYuan offers a cohesive
+  and flexible environment that adapts to your lifestyle, allowing you to access and
+  organize information effortlessly across all your devices. Whether you are a creator
+  or a regular consumer, SiYuan''s innovative approach ensures your knowledge is always
+  at your fingertips.
+
+
+  Powerful Features, Minimal Cost. SiYuan stands out with its robust set of features,
+  most of which are free, even for commercial use. Enjoy block-level referencing,
+  two-way links, custom attributes, SQL query embeds, and the unique protocol siyuan://.
+  The editor supports block-style, markdown WYSIWYG, list outlines, and block zoom-in.
+  Handle large documents with ease and include mathematical formulas, charts, flowcharts,
+  and more. Capture web content, annotate PDFs, and export in various formats including
+  Markdown, PDF, Word, and HTML. SiYuan also offers AI-powered writing and Q/A chat
+  via OpenAI API, Tesseract OCR, and multi-tab support for a comprehensive and seamless
+  experience.
+
+
+  Unlimited Storage, Local Speed, Multi-Device Access. Deploying Alist on Zima private
+  cloud devices brings unparalleled convenience. Enjoy unlimited storage, blazing-fast
+  local network speeds, and access from multiple devices. This setup ensures that
+  your data is always available, secure, and quickly accessible, providing a superior
+  alternative to traditional cloud services.
+
+  '
+maintainer: siyuan-note <auto-converted@casaos.io>
+name: siyuan-note
+package_name: casaos-siyuan-note-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Siyuan-Note/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Siyuan-Note/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Siyuan-Note/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Siyuan-Note/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/smokeping/config.yml
+++ b/sources/casaos-official/apps/smokeping/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/smokeping/docker-compose.yml
+++ b/sources/casaos-official/apps/smokeping/docker-compose.yml
@@ -1,0 +1,19 @@
+name: smokeping
+services:
+  smokeping:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/smokeping:2.8.2
+    ports:
+    - protocol: tcp
+      published: 10280
+      target: 80
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/data
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/smokeping/metadata.yaml
+++ b/sources/casaos-official/apps/smokeping/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: net
+description: Free open source network performance monitoring tool
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/icon.png
+license: Unknown
+long_description: keeps track of your network latency.
+maintainer: Lazylibrarian Team <auto-converted@casaos.io>
+name: smokeping
+package_name: casaos-smokeping-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Smokeping/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/snapdrop/config.yml
+++ b/sources/casaos-official/apps/snapdrop/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/snapdrop/docker-compose.yml
+++ b/sources/casaos-official/apps/snapdrop/docker-compose.yml
@@ -1,0 +1,19 @@
+name: snapdrop
+services:
+  snapdrop:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/snapdrop:version-eac78009
+    ports:
+    - protocol: tcp
+      published: 443
+      target: 443
+    - protocol: tcp
+      published: 89
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/snapdrop/metadata.yaml
+++ b/sources/casaos-official/apps/snapdrop/metadata.yaml
@@ -1,0 +1,17 @@
+architecture: all
+debian_section: utils
+description: Cross-platform file sharing made easy.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Snapdrop/icon.png
+license: Unknown
+long_description: Snapdrop is a Progressive Web App (PWA) that allows you to transfer
+  files between devices in the same network without having to install anything.
+maintainer: Unknown <auto-converted@casaos.io>
+name: snapdrop
+package_name: casaos-snapdrop-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Snapdrop/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/sonarr/config.yml
+++ b/sources/casaos-official/apps/sonarr/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Sonarr as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Sonarr as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/sonarr/docker-compose.yml
+++ b/sources/casaos-official/apps/sonarr/docker-compose.yml
@@ -1,0 +1,22 @@
+name: sonarr
+services:
+  sonarr:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/sonarr:4.0.15
+    ports:
+    - protocol: tcp
+      published: 8989
+      target: 8989
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/TV Shows
+      target: /tv
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind

--- a/sources/casaos-official/apps/sonarr/metadata.yaml
+++ b/sources/casaos-official/apps/sonarr/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: video
+description: The PVR for Usenet and BitTorrent users
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sonarr/icon.png
+license: Unknown
+long_description: Sonarr is a PVR for Usenet and BitTorrent users. It can monitor
+  multiple RSS feeds for new episodes of your favorite shows and will grab, sort and
+  rename them. It can also be configured to automatically upgrade the quality of files
+  already downloaded when a better quality format becomes available.
+maintainer: Sonarr <auto-converted@casaos.io>
+name: sonarr
+package_name: casaos-sonarr-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sonarr/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sonarr/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sonarr/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sonarr/screenshot-4.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/stremio/config.yml
+++ b/sources/casaos-official/apps/stremio/config.yml
@@ -1,0 +1,22 @@
+groups:
+- description: null
+  fields:
+  - default: '1'
+    description: CORS config.
+    id: NO_CORS
+    label: NO_CORS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: '1'
+    description: Enables automatic server URL detection for remote clients.
+    id: AUTO_SERVER_URL
+    label: AUTO_SERVER_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/stremio/docker-compose.yml
+++ b/sources/casaos-official/apps/stremio/docker-compose.yml
@@ -1,0 +1,18 @@
+name: stremio
+services:
+  stremio:
+    environment:
+      AUTO_SERVER_URL: ${AUTO_SERVER_URL}
+      NO_CORS: ${NO_CORS}
+    image: tsaridas/stremio-docker:v1.2.5
+    ports:
+    - protocol: tcp
+      published: 11470
+      target: 11470
+    - protocol: tcp
+      published: 8100
+      target: 8080
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /root/.stremio-server
+      type: bind

--- a/sources/casaos-official/apps/stremio/metadata.yaml
+++ b/sources/casaos-official/apps/stremio/metadata.yaml
@@ -1,0 +1,26 @@
+architecture: all
+debian_section: video
+description: Stremio is a modern media center that gives you the freedom to watch...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Stremio/icon.png
+license: Unknown
+long_description: 'Stremio is a modern media center that gives you the freedom to
+  watch everything you want.
+
+
+  Stremio offers a secure, modern and seamless entertainment experience. With its
+  easy-to-use interface and diverse content library, including 4K HDR support, users
+  can enjoy their favorite movies and TV shows across all their devices. And with
+  its commitment to security, Stremio is the ultimate choice for a worry-free, high-quality
+  streaming experience.'
+maintainer: Andreas Tsarida / Stremio <auto-converted@casaos.io>
+name: stremio
+package_name: casaos-stremio-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Stremio/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Stremio/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Stremio/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/sure/config.yml
+++ b/sources/casaos-official/apps/sure/config.yml
@@ -1,0 +1,168 @@
+groups:
+- description: null
+  fields:
+  - default: sure_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: sure_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: ${OPENAI_ACCESS_TOKEN}
+    description: ''
+    id: OPENAI_ACCESS_TOKEN
+    label: OPENAI_ACCESS_TOKEN
+    required: false
+    type: password
+  - default: sure_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: sure_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: ${OPENAI_ACCESS_TOKEN}
+    description: ''
+    id: OPENAI_ACCESS_TOKEN
+    label: OPENAI_ACCESS_TOKEN
+    required: false
+    type: password
+  - default: sure_user
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: sure_password
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: sure_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: a7523c3d0ae56415046ad8abae168d71074a79534a7062258f8d1d51ac2f76d3c3bc86d86b6b0b307df30d9a6a90a2066a3fa9e67c5e6f374dbd7dd4e0778e13
+    description: ''
+    id: SECRET_KEY_BASE
+    label: SECRET_KEY_BASE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: SELF_HOSTED
+    label: SELF_HOSTED
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_FORCE_SSL
+    label: RAILS_FORCE_SSL
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_ASSUME_SSL
+    label: RAILS_ASSUME_SSL
+    required: false
+    type: string
+  - default: sure_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: a7523c3d0ae56415046ad8abae168d71074a79534a7062258f8d1d51ac2f76d3c3bc86d86b6b0b307df30d9a6a90a2066a3fa9e67c5e6f374dbd7dd4e0778e13
+    description: ''
+    id: SECRET_KEY_BASE
+    label: SECRET_KEY_BASE
+    required: false
+    type: string
+  - default: 'true'
+    description: ''
+    id: SELF_HOSTED
+    label: SELF_HOSTED
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_FORCE_SSL
+    label: RAILS_FORCE_SSL
+    required: false
+    type: string
+  - default: 'false'
+    description: ''
+    id: RAILS_ASSUME_SSL
+    label: RAILS_ASSUME_SSL
+    required: false
+    type: string
+  - default: sure_production
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: sure-db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://sure-redis:6379/1
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  - default: sure-db
+    description: ''
+    id: DB_HOST
+    label: DB_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: ''
+    id: DB_PORT
+    label: DB_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: redis://sure-redis:6379/1
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/sure/docker-compose.yml
+++ b/sources/casaos-official/apps/sure/docker-compose.yml
@@ -1,0 +1,62 @@
+name: sure
+services:
+  sure-db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: postgres:16
+    volumes:
+    - source: /AppData/$AppID/pgdata
+      target: /var/lib/postgresql/data
+      type: bind
+  sure-redis:
+    image: redis:8.2.1-alpine3.22
+    volumes:
+    - source: /AppData/$AppID/redis/data
+      target: /data
+      type: bind
+  sure-web:
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      RAILS_ASSUME_SSL: ${RAILS_ASSUME_SSL}
+      RAILS_FORCE_SSL: ${RAILS_FORCE_SSL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      SELF_HOSTED: ${SELF_HOSTED}
+    image: ghcr.io/we-promise/sure:0.6.3
+    ports:
+    - protocol: tcp
+      published: 23000
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/app/storage
+      target: /rails/storage
+      type: bind
+  sure-worker:
+    command:
+    - bundle
+    - exec
+    - sidekiq
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      OPENAI_ACCESS_TOKEN: ${OPENAI_ACCESS_TOKEN}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      RAILS_ASSUME_SSL: ${RAILS_ASSUME_SSL}
+      RAILS_FORCE_SSL: ${RAILS_FORCE_SSL}
+      REDIS_URL: ${REDIS_URL}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      SELF_HOSTED: ${SELF_HOSTED}
+    image: ghcr.io/we-promise/sure:0.6.3
+    volumes:
+    - source: /AppData/$AppID/app/storage
+      target: /rails/storage
+      type: bind

--- a/sources/casaos-official/apps/sure/metadata.yaml
+++ b/sources/casaos-official/apps/sure/metadata.yaml
@@ -1,0 +1,59 @@
+architecture: all
+debian_section: misc
+description: Personal finance management application
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/icon.png
+license: Unknown
+long_description: 'Sure is a personal finance management application designed to help
+  you track your expenses, income, and investments in one place. With an intuitive
+  interface and powerful features, Sure makes it easy to understand your financial
+  situation and make informed decisions about your money.
+
+
+  **Key Features:**
+
+  - **Expense Tracking**: Easily log and categorize your expenses
+
+  - **Income Management**: Track multiple income sources
+
+  - **Investment Monitoring**: Keep an eye on your investments and their performance
+
+  - **Budget Planning**: Create and maintain budgets to control your spending
+
+  - **Financial Reports**: Generate detailed reports to understand your financial
+  habits
+
+  - **AI-Powered Insights**: Get personalized financial advice using AI technology
+
+
+  **Use Cases:**
+
+  - Personal budget management
+
+  - Expense tracking and categorization
+
+  - Investment portfolio monitoring
+
+  - Financial goal setting and tracking
+
+  - Cash flow analysis
+
+
+  **Learn More:**
+
+  - [Sure GitHub Repository](https://github.com/we-promise/sure)
+
+  '
+maintainer: we-promise <auto-converted@casaos.io>
+name: sure
+package_name: casaos-sure-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/screenshot-4.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Sure/screenshot-5.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/swingmusic/config.yml
+++ b/sources/casaos-official/apps/swingmusic/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/swingmusic/docker-compose.yml
+++ b/sources/casaos-official/apps/swingmusic/docker-compose.yml
@@ -1,0 +1,15 @@
+name: swingmusic
+services:
+  swingmusic:
+    image: ghcr.io/swingmx/swingmusic:v1.4.8
+    ports:
+    - protocol: tcp
+      published: 1970
+      target: 1970
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Media/Music
+      target: /music
+      type: bind

--- a/sources/casaos-official/apps/swingmusic/metadata.yaml
+++ b/sources/casaos-official/apps/swingmusic/metadata.yaml
@@ -1,0 +1,42 @@
+architecture: all
+debian_section: video
+description: Swing Music is a beautifully designed, self-hosted music streaming server.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/SwingMusic/icon.png
+license: Unknown
+long_description: 'Swing Music is a beautifully designed, self-hosted music streaming
+  server. Like a cooler Spotify ... but bring your own music.
+
+
+  Swing Music is a fast, beautiful, self-hosted music player designed for your local
+  audio files, offering a sleek experience akin to Spotify but powered by your own
+  music library. Simply run the app and access your music collection effortlessly
+  through a web browser.
+
+
+  Swing Music curates Daily Mixes based on your listening habits, ensures a clean
+  and consistent library with metadata normalization, and supports album versioning
+  (e.g., Deluxe, Remaster) alongside related artist and album recommendations. Browse
+  your music library via folder view, manage playlists, and enjoy a seamless listening
+  experience with silence detection and cross-fade. Additional features include listening
+  statistics, lyrics view, Last.fm scrobbling, multi-user support, and personalized
+  collections for grouping albums and artists.
+
+
+  With its stunning browser-based interface and robust functionality, Swing Music
+  is the perfect choice for music enthusiasts seeking a beautiful and practical way
+  to manage and enjoy their local music collection.
+
+  '
+maintainer: SwingMX <auto-converted@casaos.io>
+name: swingmusic
+package_name: casaos-swingmusic-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/SwingMusic/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/SwingMusic/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/SwingMusic/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/SwingMusic/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/syncthing/config.yml
+++ b/sources/casaos-official/apps/syncthing/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: $PGID
+    description: Run Syncthing as specified gid.
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: Run Syncthing as specified uid.
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/syncthing/docker-compose.yml
+++ b/sources/casaos-official/apps/syncthing/docker-compose.yml
@@ -1,0 +1,28 @@
+name: syncthing
+services:
+  syncthing:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/syncthing:1.29.7
+    ports:
+    - protocol: tcp
+      published: 8384
+      target: 8384
+    - protocol: tcp
+      published: 22000
+      target: 22000
+    - protocol: udp
+      published: 22000
+      target: 22000
+    - protocol: udp
+      published: 21027
+      target: 21027
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/DATA
+      target: /DATA
+      type: bind

--- a/sources/casaos-official/apps/syncthing/metadata.yaml
+++ b/sources/casaos-official/apps/syncthing/metadata.yaml
@@ -1,0 +1,47 @@
+architecture: all
+debian_section: admin
+description: Open decentralized file synchronization
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Syncthing/icon.png
+license: Unknown
+long_description: '# Unlocking the True Potential of Data Backup
+
+
+  Say goodbye to traditional cloud backup limitations and embrace the future with
+  Syncthing. Unlike conventional cloud services that often come with privacy concerns
+  and storage restrictions, Syncthing provides a secure, real-time file synchronization
+  solution that keeps your data exclusively in your hands. Whether you''re syncing
+  work documents or personal photos, you have complete control over where and how
+  your files are stored and shared.
+
+
+  # Features That Make a Difference
+
+
+  Syncthing offers a seamless, user-friendly experience with powerful features designed
+  for everyday users. Enjoy continuous file synchronization between multiple devices
+  without any subscription fees. Experience peace of mind knowing that your data is
+  encrypted and protected from unauthorized access. Syncthing’s open-source nature
+  means no hidden costs, providing a truly transparent and cost-effective solution
+  for your file management needs.
+
+
+  # The Power of Syncthing on Zima
+
+
+  Deploying Syncthing on Zima private cloud devices unlocks unparalleled convenience:
+  enjoy unlimited storage capacity, ensure the privacy of your data, and benefit from
+  blazing local network speeds. Transform your data management and synchronization
+  with the perfect combination of Syncthing’s capabilities and Zima’s powerful infrastructure.
+
+  '
+maintainer: Syncthing <auto-converted@casaos.io>
+name: syncthing
+package_name: casaos-syncthing-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Syncthing/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Syncthing/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/tailscale/config.yml
+++ b/sources/casaos-official/apps/tailscale/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: /var/lib/tailscale
+    description: Tailscale State Directory Path
+    id: TS_STATE_DIR
+    label: TS_STATE_DIR
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/tailscale/docker-compose.yml
+++ b/sources/casaos-official/apps/tailscale/docker-compose.yml
@@ -1,0 +1,16 @@
+name: tailscale
+services:
+  tailscale:
+    entrypoint:
+    - /bin/sh -c "tailscaled --state=/var/lib/tailscale/tailscaled.state & sleep 10;
+      tailscale web --listen 0.0.0.0:5252"
+    environment:
+      TS_STATE_DIR: ${TS_STATE_DIR}
+    image: tailscale/tailscale:v1.90.8
+    volumes:
+    - source: /AppData/$AppID
+      target: /var/lib/tailscale
+      type: bind
+    - source: /dev/net/tun
+      target: /dev/net/tun
+      type: bind

--- a/sources/casaos-official/apps/tailscale/metadata.yaml
+++ b/sources/casaos-official/apps/tailscale/metadata.yaml
@@ -1,0 +1,77 @@
+architecture: all
+debian_section: net
+description: Connect your devices and users together in your own secure virtual private...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tailscale/icon.png
+license: Unknown
+long_description: 'Connect your devices and users together in your own secure virtual
+  private network.
+
+
+  A modern self-hosted networking app built on WireGuard®, providing secure, encrypted
+  connections between devices regardless of their location. Its zero-configuration
+  networking eliminates the need for complex firewall rules, port forwarding, or network
+  administration, making it ideal for businesses and individuals creating efficient,
+  secure network environments.
+
+
+  The app''s core features include seamless device connectivity and robust security.
+  It uses WireGuard® for end-to-end encryption, ensuring traffic cannot be intercepted,
+  with private keys stored solely on user devices. Automatic NAT traversal enables
+  connections across computers, phones, servers, and IoT devices over different network
+  types, forming a unified private network. It also offers identity-based access control,
+  integrating with Google, Microsoft, GitHub, or custom SSO solutions for simple authentication,
+  replacing traditional IP-based restrictions to enhance security.
+
+
+  It excels in delivering secure remote access to services and infrastructure. Users
+  can effortlessly access home servers, connect to office networks while traveling,
+  or establish secure links between cloud services. Subnet routing allows access to
+  entire networks, exit nodes enable secure internet browsing, and MagicDNS simplifies
+  device discovery. These features ensure efficient, secure access to resources from
+  any location.
+
+
+  It supports nearly all platforms, including Linux, Windows, macOS, iOS, Android,
+  and various router firmwares, with flexible deployment in cloud or on-premises environments.
+  A user-friendly Web interface provides real-time monitoring of network topology,
+  device status, and access controls, with community documentation aiding configuration
+  optimization. Whether setting up secure access for small teams or managing enterprise-scale
+  networks, the app’s intuitive operation and high flexibility deliver a modern networking
+  solution.
+
+
+  **Key Features:**
+
+  - End-to-end encryption via WireGuard®, ensuring uninterceptible traffic
+
+  - Zero-configuration networking, eliminating complex firewall or port forwarding
+  setup
+
+  - Automatic NAT traversal for seamless device connectivity across network types
+
+  - Identity-based access control with SSO integration (Google, Microsoft, GitHub)
+
+  - Subnet routing for secure network-wide access
+
+  - Exit nodes for safe internet browsing
+
+  - MagicDNS for simplified device discovery
+
+
+  **Learn More:**
+
+  - [Tailscale Official Website](https://tailscale.com)
+
+  - [Tailscale GitHub Repository](https://github.com/tailscale/tailscale)
+
+  '
+maintainer: Tailscale Inc. <auto-converted@casaos.io>
+name: tailscale
+package_name: casaos-tailscale-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tailscale/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/taskingai/config.yml
+++ b/sources/casaos-official/apps/taskingai/config.yml
@@ -1,0 +1,218 @@
+groups:
+- description: null
+  fields:
+  - default: b90e4648ad699c3bdf62c0860e09eb9efc098ee75f215bf750847ae19d41e4b0
+    description: ''
+    id: AES_ENCRYPTION_KEY
+    label: AES_ENCRYPTION_KEY
+    required: false
+    type: password
+  - default: b90e4648ad699c3bdf62c0860e09eb9efc098ee75f215bf750847ae19d41e4b0
+    description: ''
+    id: AES_ENCRYPTION_KEY
+    label: AES_ENCRYPTION_KEY
+    required: false
+    type: password
+  - default: b90e4648ad699c3bdf62c0860e09eb9efc098ee75f215bf750847ae19d41e4b0
+    description: ''
+    id: AES_ENCRYPTION_KEY
+    label: AES_ENCRYPTION_KEY
+    required: false
+    type: password
+  - default: b90e4648ad699c3bdf62c0860e09eb9efc098ee75f215bf750847ae19d41e4b0
+    description: ''
+    id: AES_ENCRYPTION_KEY
+    label: AES_ENCRYPTION_KEY
+    required: false
+    type: password
+  - default: dbefe42f34473990a3fa903a6a3283acdc3a910beb1ae271a6463ffa5a926bfb
+    description: ''
+    id: JWT_SECRET_KEY
+    label: JWT_SECRET_KEY
+    required: false
+    type: password
+  - default: admin
+    description: ''
+    id: DEFAULT_ADMIN_USERNAME
+    label: DEFAULT_ADMIN_USERNAME
+    required: false
+    type: string
+  - default: TaskingAI321
+    description: ''
+    id: DEFAULT_ADMIN_PASSWORD
+    label: DEFAULT_ADMIN_PASSWORD
+    required: false
+    type: password
+  - default: postgres
+    description: ''
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: TaskingAI321
+    description: ''
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: http://nginx:3080
+    description: ''
+    id: ICON_URL_PREFIX
+    label: ICON_URL_PREFIX
+    required: false
+    type: string
+  - default: taskingai
+    description: ''
+    id: PROJECT_ID
+    label: PROJECT_ID
+    required: false
+    type: string
+  - default: http://nginx:3080
+    description: ''
+    id: ICON_URL_PREFIX
+    label: ICON_URL_PREFIX
+    required: false
+    type: string
+  - default: local
+    description: ''
+    id: OBJECT_STORAGE_TYPE
+    label: OBJECT_STORAGE_TYPE
+    required: false
+    type: string
+  - default: /var/lib/data
+    description: ''
+    id: PATH_TO_VOLUME
+    label: PATH_TO_VOLUME
+    required: false
+    type: string
+  - default: taskingai
+    description: ''
+    id: PROJECT_ID
+    label: PROJECT_ID
+    required: false
+    type: string
+  - default: local
+    description: ''
+    id: OBJECT_STORAGE_TYPE
+    label: OBJECT_STORAGE_TYPE
+    required: false
+    type: string
+  - default: /var/lib/data
+    description: ''
+    id: PATH_TO_VOLUME
+    label: PATH_TO_VOLUME
+    required: false
+    type: string
+  - default: taskingai
+    description: ''
+    id: PROJECT_ID
+    label: PROJECT_ID
+    required: false
+    type: string
+  - default: WEB
+    description: ''
+    id: PURPOSE
+    label: PURPOSE
+    required: false
+    type: string
+  - default: local
+    description: ''
+    id: OBJECT_STORAGE_TYPE
+    label: OBJECT_STORAGE_TYPE
+    required: false
+    type: string
+  - default: /var/lib/data
+    description: ''
+    id: PATH_TO_VOLUME
+    label: PATH_TO_VOLUME
+    required: false
+    type: string
+  - default: taskingai
+    description: ''
+    id: PROJECT_ID
+    label: PROJECT_ID
+    required: false
+    type: string
+  - default: taskingai
+    description: ''
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: http://nginx:3080
+    description: ''
+    id: HOST_URL
+    label: HOST_URL
+    required: false
+    type: string
+  - default: postgres://postgres:TaskingAI321@db:5432/taskingai
+    description: ''
+    id: POSTGRES_URL
+    label: POSTGRES_URL
+    required: false
+    type: string
+  - default: redis://:TaskingAI321@cache:6379/0
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  - default: http://backend-inference:8000
+    description: ''
+    id: TASKINGAI_INFERENCE_URL
+    label: TASKINGAI_INFERENCE_URL
+    required: false
+    type: string
+  - default: http://backend-plugin:8000
+    description: ''
+    id: TASKINGAI_PLUGIN_URL
+    label: TASKINGAI_PLUGIN_URL
+    required: false
+    type: string
+  - default: http://nginx:3080
+    description: ''
+    id: HOST_URL
+    label: HOST_URL
+    required: false
+    type: string
+  - default: postgres://postgres:TaskingAI321@db:5432/taskingai
+    description: ''
+    id: POSTGRES_URL
+    label: POSTGRES_URL
+    required: false
+    type: string
+  - default: redis://:TaskingAI321@cache:6379/0
+    description: ''
+    id: REDIS_URL
+    label: REDIS_URL
+    required: false
+    type: string
+  - default: http://backend-inference:8000
+    description: ''
+    id: TASKINGAI_INFERENCE_URL
+    label: TASKINGAI_INFERENCE_URL
+    required: false
+    type: string
+  - default: http://backend-plugin:8000
+    description: ''
+    id: TASKINGAI_PLUGIN_URL
+    label: TASKINGAI_PLUGIN_URL
+    required: false
+    type: string
+  - default: http://nginx:3080
+    description: ''
+    id: HOST_URL
+    label: HOST_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/taskingai/docker-compose.yml
+++ b/sources/casaos-official/apps/taskingai/docker-compose.yml
@@ -1,0 +1,89 @@
+name: taskingai
+services:
+  backend-api:
+    environment:
+      AES_ENCRYPTION_KEY: ${AES_ENCRYPTION_KEY}
+      HOST_URL: ${HOST_URL}
+      OBJECT_STORAGE_TYPE: ${OBJECT_STORAGE_TYPE}
+      PATH_TO_VOLUME: ${PATH_TO_VOLUME}
+      POSTGRES_URL: ${POSTGRES_URL}
+      PROJECT_ID: ${PROJECT_ID}
+      REDIS_URL: ${REDIS_URL}
+      TASKINGAI_INFERENCE_URL: ${TASKINGAI_INFERENCE_URL}
+      TASKINGAI_PLUGIN_URL: ${TASKINGAI_PLUGIN_URL}
+    image: taskingai/taskingai-server:v0.3.0
+    volumes:
+    - source: /AppData/$AppID/data/object_storage
+      target: /var/lib/data
+      type: bind
+  backend-inference:
+    environment:
+      AES_ENCRYPTION_KEY: ${AES_ENCRYPTION_KEY}
+      ICON_URL_PREFIX: ${ICON_URL_PREFIX}
+      PROJECT_ID: ${PROJECT_ID}
+    image: taskingai/taskingai-inference:v0.2.14
+  backend-plugin:
+    environment:
+      AES_ENCRYPTION_KEY: ${AES_ENCRYPTION_KEY}
+      HOST_URL: ${HOST_URL}
+      ICON_URL_PREFIX: ${ICON_URL_PREFIX}
+      OBJECT_STORAGE_TYPE: ${OBJECT_STORAGE_TYPE}
+      PATH_TO_VOLUME: ${PATH_TO_VOLUME}
+      PROJECT_ID: ${PROJECT_ID}
+    image: taskingai/taskingai-plugin:v0.2.10
+    volumes:
+    - source: /AppData/$AppID/data/object_storage
+      target: /var/lib/data
+      type: bind
+  backend-web:
+    environment:
+      AES_ENCRYPTION_KEY: ${AES_ENCRYPTION_KEY}
+      DEFAULT_ADMIN_PASSWORD: ${DEFAULT_ADMIN_PASSWORD}
+      DEFAULT_ADMIN_USERNAME: ${DEFAULT_ADMIN_USERNAME}
+      HOST_URL: ${HOST_URL}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      OBJECT_STORAGE_TYPE: ${OBJECT_STORAGE_TYPE}
+      PATH_TO_VOLUME: ${PATH_TO_VOLUME}
+      POSTGRES_URL: ${POSTGRES_URL}
+      PROJECT_ID: ${PROJECT_ID}
+      PURPOSE: ${PURPOSE}
+      REDIS_URL: ${REDIS_URL}
+      TASKINGAI_INFERENCE_URL: ${TASKINGAI_INFERENCE_URL}
+      TASKINGAI_PLUGIN_URL: ${TASKINGAI_PLUGIN_URL}
+    image: taskingai/taskingai-server:v0.3.0
+    volumes:
+    - source: /AppData/$AppID/data/object_storage
+      target: /var/lib/data
+      type: bind
+  cache:
+    command:
+    - redis-server
+    - --requirepass
+    - TaskingAI321
+    image: redis:7-alpine
+    volumes:
+    - source: /AppData/$AppID/data/redis
+      target: /data
+      type: bind
+  db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: ankane/pgvector:v0.5.1
+    volumes:
+    - source: /AppData/$AppID/data/postgres
+      target: /var/lib/postgresql/data
+      type: bind
+  frontend:
+    image: taskingai/taskingai-console:v0.3.0
+  nginx:
+    image: nginx:1.24
+    ports:
+    - protocol: tcp
+      published: 3080
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/data/nginx_cache
+      target: /var/cache/nginx
+      type: bind

--- a/sources/casaos-official/apps/taskingai/metadata.yaml
+++ b/sources/casaos-official/apps/taskingai/metadata.yaml
@@ -1,0 +1,24 @@
+architecture: all
+debian_section: comm
+description: The developer-friendly cloud platform for building and running LLM agents...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/TaskingAI/icon.png
+license: Unknown
+long_description: 'The developer-friendly cloud platform for building and running
+  LLM agents for AI-native applications.
+
+
+  The developer-friendly cloud platform for building and running LLM agents for AI-native
+  applications.'
+maintainer: TaskingAI Team <auto-converted@casaos.io>
+name: taskingai
+package_name: casaos-taskingai-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/TaskingAI/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/TaskingAI/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/TaskingAI/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/TaskingAI/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/tautulli/config.yml
+++ b/sources/casaos-official/apps/tautulli/config.yml
@@ -1,0 +1,28 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/tautulli/docker-compose.yml
+++ b/sources/casaos-official/apps/tautulli/docker-compose.yml
@@ -1,0 +1,16 @@
+name: tautulli
+services:
+  tautulli:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: linuxserver/tautulli:2.13.2
+    ports:
+    - protocol: tcp
+      published: 8181
+      target: 8181
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/tautulli/metadata.yaml
+++ b/sources/casaos-official/apps/tautulli/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: video
+description: Monitor your Plex Media Server and much more.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tautulli/icon.png
+license: Unknown
+long_description: Tautulli is a 3rd party application that you can run alongside your
+  Plex Media Server to monitor activity and track various statistics.
+maintainer: Tautulli Team <auto-converted@casaos.io>
+name: tautulli
+package_name: casaos-tautulli-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tautulli/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tautulli/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tautulli/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Tautulli/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/threadfin/config.yml
+++ b/sources/casaos-official/apps/threadfin/config.yml
@@ -1,0 +1,18 @@
+groups:
+- description: null
+  fields:
+  - default: main
+    description: 'Set Threadfin git branch [ main, beta, dev ] Default: beta'
+    id: THREADFIN_BRANCH
+    label: THREADFIN_BRANCH
+    required: false
+    type: string
+  - default: '0'
+    description: 'Set Threadfin debug level [ 0-3 ] Default: 0=OFF'
+    id: THREADFIN_DEBUG
+    label: THREADFIN_DEBUG
+    required: false
+    type: boolean
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/threadfin/docker-compose.yml
+++ b/sources/casaos-official/apps/threadfin/docker-compose.yml
@@ -1,0 +1,18 @@
+name: threadfin
+services:
+  threadfin:
+    environment:
+      THREADFIN_BRANCH: ${THREADFIN_BRANCH}
+      THREADFIN_DEBUG: ${THREADFIN_DEBUG}
+    image: fyb3roptik/threadfin:latest
+    ports:
+    - protocol: tcp
+      published: 34400
+      target: 34400
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/config
+      target: /home/threadfin/conf/data
+      type: bind
+    - source: ${CONTAINER_DATA_ROOT}/backup
+      target: /home/threadfin/conf/backup
+      type: bind

--- a/sources/casaos-official/apps/threadfin/metadata.yaml
+++ b/sources/casaos-official/apps/threadfin/metadata.yaml
@@ -1,0 +1,16 @@
+architecture: all
+debian_section: utils
+description: M3U proxy server
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Threadfin/icon.png
+license: Unknown
+long_description: Threadfin is a M3U proxy server for Plex, Emby, Jellyfin and any
+  client and provider which supports the .TS and .M3U8 (HLS) streaming formats.
+maintainer: jdownloader <auto-converted@casaos.io>
+name: threadfin
+package_name: casaos-threadfin-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/transmission/config.yml
+++ b/sources/casaos-official/apps/transmission/config.yml
@@ -1,0 +1,60 @@
+groups:
+- description: null
+  fields:
+  - default: casaos
+    description: ''
+    id: PASS
+    label: PASS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: '51413'
+    description: ''
+    id: PEERPORT
+    label: PEERPORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/London
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: ''
+    id: USER
+    label: USER
+    required: false
+    type: string
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/transmission/docker-compose.yml
+++ b/sources/casaos-official/apps/transmission/docker-compose.yml
@@ -1,0 +1,31 @@
+name: transmission
+services:
+  transmission:
+    environment:
+      PASS: ${PASS}
+      PEERPORT: ${PEERPORT}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+      USER: ${USER}
+    image: linuxserver/transmission:4.0.4
+    ports:
+    - protocol: tcp
+      published: 9091
+      target: 9091
+    - protocol: tcp
+      published: 51413
+      target: 51413
+    - protocol: tcp
+      published: 51413
+      target: 51413
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind
+    - source: /Downloads
+      target: /downloads
+      type: bind
+    - source: /Downloads/watch
+      target: /watch
+      type: bind

--- a/sources/casaos-official/apps/transmission/metadata.yaml
+++ b/sources/casaos-official/apps/transmission/metadata.yaml
@@ -1,0 +1,32 @@
+architecture: all
+debian_section: misc
+description: Transmission is a cross-platform BitTorrent client
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Transmission/icon.png
+license: Unknown
+long_description: 'Transmission is a BitTorrent client designed for simplicity and
+  powerful performance, delivering an efficient and user-friendly downloading experience.
+  It comes equipped with all the essential features you expect, including encryption,
+  a web interface, peer exchange, magnet links, DHT, µTP, UPnP and NAT-PMP port forwarding,
+  webseed support, watch directories, tracker editing, global and per-torrent speed
+  limits, and more.
+
+
+  With its intuitive interface, Transmission caters to both beginners and advanced
+  users. Whether you’re managing a single download or juggling complex torrent queues,
+  Transmission ensures a seamless experience with optimized resource usage and reliable
+  performance. For casual users and tech enthusiasts alike, Transmission is the ideal
+  BitTorrent solution.
+
+  '
+maintainer: Transmission <auto-converted@casaos.io>
+name: transmission
+package_name: casaos-transmission-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Transmission/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Transmission/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Transmission/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ttydbridge/config.yml
+++ b/sources/casaos-official/apps/ttydbridge/config.yml
@@ -1,0 +1,34 @@
+groups:
+- description: null
+  fields:
+  - default: /opt
+    description: ''
+    id: EXEC_DIR
+    label: EXEC_DIR
+    required: false
+    type: path
+  id: storage
+  label: Storage Configuration
+- description: null
+  fields:
+  - default: '2222'
+    description: ''
+    id: PORT
+    label: PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: login
+    description: ''
+    id: START_COMMAND
+    label: START_COMMAND
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/ttydbridge/docker-compose.yml
+++ b/sources/casaos-official/apps/ttydbridge/docker-compose.yml
@@ -1,0 +1,12 @@
+name: ttydbridge
+services:
+  ttydbridge:
+    environment:
+      EXEC_DIR: ${EXEC_DIR}
+      PORT: ${PORT}
+      START_COMMAND: ${START_COMMAND}
+    image: cp0204/ttydbridge:v0.0.3
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}/opt
+      target: /opt
+      type: bind

--- a/sources/casaos-official/apps/ttydbridge/metadata.yaml
+++ b/sources/casaos-official/apps/ttydbridge/metadata.yaml
@@ -1,0 +1,22 @@
+architecture: all
+debian_section: devel
+description: Easy access to the host terminal in web
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ttydbridge/icon.png
+license: Unknown
+long_description: 'ttydBridge acts as a "bridge" to the host environment, allowing
+  you to easily access and use the host terminal in a web. It is built on ttyd and
+  runs in a containerized manner, providing a secure and convenient remote endpoint
+  experience.
+
+  '
+maintainer: Cp0204 <auto-converted@casaos.io>
+name: ttydbridge
+package_name: casaos-ttydbridge-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ttydbridge/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/ttydbridge/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/twingate-connector/config.yml
+++ b/sources/casaos-official/apps/twingate-connector/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: ''
+    description: ''
+    id: TWINGATE_NETWORK
+    label: TWINGATE_NETWORK
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: ''
+    description: ''
+    id: TWINGATE_ACCESS_TOKEN
+    label: TWINGATE_ACCESS_TOKEN
+    required: false
+    type: password
+  - default: ''
+    description: ''
+    id: TWINGATE_REFRESH_TOKEN
+    label: TWINGATE_REFRESH_TOKEN
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: ${HOSTNAME}
+    description: ''
+    id: TWINGATE_LABEL_HOSTNAME
+    label: TWINGATE_LABEL_HOSTNAME
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+version: '1.0'

--- a/sources/casaos-official/apps/twingate-connector/docker-compose.yml
+++ b/sources/casaos-official/apps/twingate-connector/docker-compose.yml
@@ -1,0 +1,11 @@
+name: twingate-connector
+services:
+  twingate-connector:
+    command:
+    - /connectord
+    environment:
+      TWINGATE_ACCESS_TOKEN: ${TWINGATE_ACCESS_TOKEN}
+      TWINGATE_LABEL_HOSTNAME: ${TWINGATE_LABEL_HOSTNAME}
+      TWINGATE_NETWORK: ${TWINGATE_NETWORK}
+      TWINGATE_REFRESH_TOKEN: ${TWINGATE_REFRESH_TOKEN}
+    image: twingate/connector:1

--- a/sources/casaos-official/apps/twingate-connector/metadata.yaml
+++ b/sources/casaos-official/apps/twingate-connector/metadata.yaml
@@ -1,0 +1,15 @@
+architecture: all
+debian_section: net
+description: Twingate Connector for CasaOS
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Twingate/icon.png
+license: Unknown
+long_description: It's a connector for Twingate".
+maintainer: Twingate <auto-converted@casaos.io>
+name: twingate-connector
+package_name: casaos-twingate-connector-container
+screenshots: null
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/unifi-controller/config.yml
+++ b/sources/casaos-official/apps/unifi-controller/config.yml
@@ -1,0 +1,38 @@
+groups:
+- description: null
+  fields:
+  - default: '1024'
+    description: ''
+    id: MEM_LIMIT
+    label: MEM_LIMIT
+    required: false
+    type: integer
+  - default: '1024'
+    description: ''
+    id: MEM_STARTUP
+    label: MEM_STARTUP
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: '1000'
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/unifi-controller/docker-compose.yml
+++ b/sources/casaos-official/apps/unifi-controller/docker-compose.yml
@@ -1,0 +1,41 @@
+name: unifi-controller
+services:
+  unifi-controller:
+    environment:
+      MEM_LIMIT: ${MEM_LIMIT}
+      MEM_STARTUP: ${MEM_STARTUP}
+      PGID: ${PGID}
+      PUID: ${PUID}
+    image: linuxserver/unifi-controller:8.0.7
+    ports:
+    - protocol: udp
+      published: 3478
+      target: 3478
+    - protocol: udp
+      published: 10001
+      target: 10001
+    - protocol: tcp
+      published: 8383
+      target: 8080
+    - protocol: tcp
+      published: 8443
+      target: 8443
+    - protocol: udp
+      published: 1900
+      target: 1900
+    - protocol: tcp
+      published: 8843
+      target: 8843
+    - protocol: tcp
+      published: 8880
+      target: 8880
+    - protocol: tcp
+      published: 6789
+      target: 6789
+    - protocol: udp
+      published: 5514
+      target: 5514
+    volumes:
+    - source: /AppData/$AppID/config
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/unifi-controller/metadata.yaml
+++ b/sources/casaos-official/apps/unifi-controller/metadata.yaml
@@ -1,0 +1,29 @@
+architecture: all
+debian_section: net
+description: The Unifi-controller software is a powerful, enterprise wireless software...
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-controller/icon.png
+license: Unknown
+long_description: 'The Unifi-controller software is a powerful, enterprise wireless
+  software engine ideal for high-density client deployments requiring low latency
+  and high uptime performance.
+
+
+  For Unifi to adopt other devices, e.g. an Access Point, it is required to change
+  the inform IP address. Because Unifi runs inside Docker by default it uses an IP
+  address not accessible by other devices. To change this go to Settings > System
+  Settings > Controller Configuration and set the Controller Hostname/IP to a hostname
+  or IP address accessible by your devices. Additionally the checkbox "Override inform
+  host with controller hostname/IP" has to be checked, so that devices can connect
+  to the controller during adoption (devices use the inform-endpoint during adoption).'
+maintainer: LinuxServer.io <auto-converted@casaos.io>
+name: unifi-controller
+package_name: casaos-unifi-controller-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-controller/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-controller/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-controller/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/unifi-network-application/config.yml
+++ b/sources/casaos-official/apps/unifi-network-application/config.yml
@@ -1,0 +1,94 @@
+groups:
+- description: null
+  fields:
+  - default: unifi-db
+    description: ''
+    id: MONGO_DBNAME
+    label: MONGO_DBNAME
+    required: false
+    type: string
+  - default: pass
+    description: ''
+    id: MONGO_PASS
+    label: MONGO_PASS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: unifi-db
+    description: ''
+    id: MONGO_HOST
+    label: MONGO_HOST
+    required: false
+    type: string
+  - default: '27017'
+    description: ''
+    id: MONGO_PORT
+    label: MONGO_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: unifi
+    description: ''
+    id: MONGO_USER
+    label: MONGO_USER
+    required: false
+    type: string
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: timezone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  - default: $PGID
+    description: ''
+    id: PGID
+    label: PGID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $PUID
+    description: ''
+    id: PUID
+    label: PUID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: $TZ
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/unifi-network-application/docker-compose.yml
+++ b/sources/casaos-official/apps/unifi-network-application/docker-compose.yml
@@ -1,0 +1,44 @@
+name: unifi-network-application
+services:
+  unifi-db:
+    environment:
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: docker.io/mongo:3.6
+    ports:
+    - protocol: tcp
+      published: 27017
+      target: 27017
+    volumes:
+    - source: /AppData/unifi-db
+      target: /data/db
+      type: bind
+  unifi-network-application:
+    environment:
+      MONGO_DBNAME: ${MONGO_DBNAME}
+      MONGO_HOST: ${MONGO_HOST}
+      MONGO_PASS: ${MONGO_PASS}
+      MONGO_PORT: ${MONGO_PORT}
+      MONGO_USER: ${MONGO_USER}
+      PGID: ${PGID}
+      PUID: ${PUID}
+      TZ: ${TZ}
+    image: lscr.io/linuxserver/unifi-network-application:latest
+    ports:
+    - protocol: tcp
+      published: 8443
+      target: 8443
+    - protocol: udp
+      published: 3478
+      target: 3478
+    - protocol: udp
+      published: 10001
+      target: 10001
+    - protocol: tcp
+      published: 8080
+      target: 8080
+    volumes:
+    - source: ${CONTAINER_DATA_ROOT}
+      target: /config
+      type: bind

--- a/sources/casaos-official/apps/unifi-network-application/metadata.yaml
+++ b/sources/casaos-official/apps/unifi-network-application/metadata.yaml
@@ -1,0 +1,41 @@
+architecture: all
+debian_section: net
+description: The Unifi network application software is a powerful
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-Network-Application/icon.png
+license: Unknown
+long_description: 'The Unifi network application software is a powerful, enterprise
+  wireless software engine ideal for high-density client deployments requiring low
+  latency and high uptime performance.
+
+
+  Only mandatory ports are enabled by default, to extend functionality consider exposing
+  1900:1900/udp, 8843:8843, 8880:8880, 6789:6789, 5514:5514/udp.
+
+  Other ports specifications [here](https://docs.linuxserver.io/images/docker-unifi-network-application/#ports-p).
+
+
+  Because the network application runs inside Docker by default it uses an IP address
+  not accessible by other devices.
+
+  So, for it to adopt other devices, it is required to use port `8080` and change
+  the inform IP address. To do so, go in settings and search for the `Inform Host`
+  option, there select override and set the address to that of the host.
+
+  Often, it is also needed to ssh into the devices you want to adopt and manually
+  set the inform IP address, the command needed for doing so is `set-inform http://HOST-ADDRESS:8080/inform`.
+
+
+  For more [information](https://docs.linuxserver.io/images/docker-unifi-network-application/)
+
+  '
+maintainer: Ubiquiti and Linuxserver.io <auto-converted@casaos.io>
+name: unifi-network-application
+package_name: casaos-unifi-network-application-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-Network-Application/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Unifi-Network-Application/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/uptimekuma/config.yml
+++ b/sources/casaos-official/apps/uptimekuma/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/uptimekuma/docker-compose.yml
+++ b/sources/casaos-official/apps/uptimekuma/docker-compose.yml
@@ -1,0 +1,12 @@
+name: uptimekuma
+services:
+  uptimekuma:
+    image: louislam/uptime-kuma:1.23.16-alpine
+    ports:
+    - protocol: tcp
+      published: 3001
+      target: 3001
+    volumes:
+    - source: /AppData/$AppID/app/data
+      target: /app/data
+      type: bind

--- a/sources/casaos-official/apps/uptimekuma/metadata.yaml
+++ b/sources/casaos-official/apps/uptimekuma/metadata.yaml
@@ -1,0 +1,68 @@
+architecture: all
+debian_section: net
+description: A fancy monitoring tool
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/icon.png
+license: Unknown
+long_description: 'Uptime Kuma is a free, easy-to-use self-hosted monitoring tool
+  designed for real-time tracking of network services and infrastructure, offering
+  a modern interface and robust functionality. It provides an intuitive Web dashboard
+  for managing services, ideal for individual developers, home lab users, and small
+  teams.
+
+
+  The tool''s core features include comprehensive monitoring and diverse notification
+  channels. It monitors HTTP/HTTPS, TCP ports, DNS records, databases, Ping, and Steam
+  game servers, with interactive Ping charts visually displaying response times and
+  status. Users can receive real-time alerts via Telegram, Discord, Slack, Email (SMTP),
+  and over 95 other notification services. SSL certificate monitoring checks certificate
+  validity and expiration, aiding timely renewals.
+
+
+  It supports 20-second monitoring intervals for rapid downtime detection and offers
+  multiple status pages to share real-time service status with customers. Proxy support
+  enables remote access via Cloudflare, Nginx, or similar services, enhancing flexibility.
+  Two-factor authentication (2FA) and API keys bolster security, ensuring full user
+  control over local data. The tool delivers an efficient monitoring solution with
+  intuitive operation and community support.
+
+
+  **Key Features:**
+
+  - Monitor HTTP/HTTPS, TCP, DNS, databases, and other services
+
+  - Notifications via Telegram, Discord, Slack, and over 95 other channels
+
+  - Interactive Ping charts displaying response times and status
+
+  - SSL certificate monitoring for validity and expiration
+
+  - 20-second monitoring intervals for rapid downtime detection
+
+  - Multiple status pages for sharing service status
+
+  - Proxy support compatible with Cloudflare, Nginx, and more
+
+  - Two-factor authentication (2FA) and API keys for enhanced security
+
+
+  **Learn More:**
+
+  - [Uptime Kuma Official Website](https://uptimekuma.org)
+
+  - [Uptime Kuma GitHub Repository](https://github.com/louislam/uptime-kuma)
+
+  '
+maintainer: Louis Lam <auto-converted@casaos.io>
+name: uptimekuma
+package_name: casaos-uptimekuma-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/screenshot-4.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/UptimeKuma/screenshot-5.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/v2raya/config.yml
+++ b/sources/casaos-official/apps/v2raya/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/v2raya/docker-compose.yml
+++ b/sources/casaos-official/apps/v2raya/docker-compose.yml
@@ -1,0 +1,15 @@
+name: v2raya
+services:
+  v2raya:
+    image: mzz2017/v2raya:v2.2.6.7
+    volumes:
+    - read_only: true
+      source: ${CONTAINER_DATA_ROOT}/lib/modules
+      target: /lib/modules
+      type: bind
+    - source: /etc/resolv.conf
+      target: /etc/resolv.conf
+      type: bind
+    - source: /AppData/$AppID
+      target: /etc/v2raya
+      type: bind

--- a/sources/casaos-official/apps/v2raya/metadata.yaml
+++ b/sources/casaos-official/apps/v2raya/metadata.yaml
@@ -1,0 +1,61 @@
+architecture: all
+debian_section: net
+description: A web GUI client of Project V which supports VMess, VLESS, SS, SSR, Trojan
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/V2rayA/icon.png
+license: Unknown
+long_description: 'A web GUI client of Project V which supports VMess, VLESS, SS,
+  SSR, Trojan, Tuic and Juicity protocols
+
+
+  v2rayA is a V2Ray client supporting global transparent proxy, compatible with SS,
+  SSR, Trojan (trojan-go), Tuic, and Juicity protocols. Designed for simplicity, it
+  meets most user needs, ideal for scenarios requiring efficient proxy services.
+
+
+  Core features include global transparent proxy and multi-outbound load balancing
+  with traffic splitting. It provides proxy services for nearly all applications without
+  requiring application-specific proxy support. Support for creating and connecting
+  multiple outbound nodes ensures load balancing and efficient traffic splitting for
+  optimal network performance.
+
+
+  It offers RoutingA, a custom routing language for V2Ray, providing powerful and
+  convenient traffic splitting support. Multiple strategies address DNS pollution,
+  with advanced settings enabling customized configurations. With simplicity and functionality
+  at the core, the platform delivers a modern solution for proxy management.
+
+
+  **Key Features:**
+
+  - Web-based GUI for easy configuration and management
+
+  - Support for multiple protocols: VMess, VLESS, SS, SSR, Trojan, Tuic, Juicity
+
+  - Global transparent proxy for seamless application proxy services
+
+  - Multi-outbound load balancing and traffic splitting
+
+  - RoutingA custom routing for convenient traffic splitting
+
+  - Multiple DNS pollution mitigation strategies with advanced custom settings
+
+
+  **Learn More:**
+
+  - [V2rayA Official Website](https://v2raya.org/)
+
+  - [V2rayA GitHub](https://github.com/v2rayA/v2rayA)
+
+  '
+maintainer: v2rayA <auto-converted@casaos.io>
+name: v2raya
+package_name: casaos-v2raya-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/V2rayA/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/V2rayA/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/V2rayA/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/vaultwarden/config.yml
+++ b/sources/casaos-official/apps/vaultwarden/config.yml
@@ -1,0 +1,2 @@
+groups: []
+version: '1.0'

--- a/sources/casaos-official/apps/vaultwarden/docker-compose.yml
+++ b/sources/casaos-official/apps/vaultwarden/docker-compose.yml
@@ -1,0 +1,12 @@
+name: vaultwarden
+services:
+  vaultwarden:
+    image: vaultwarden/server:1.32.7
+    ports:
+    - protocol: tcp
+      published: 10380
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/data
+      target: /data
+      type: bind

--- a/sources/casaos-official/apps/vaultwarden/metadata.yaml
+++ b/sources/casaos-official/apps/vaultwarden/metadata.yaml
@@ -1,0 +1,20 @@
+architecture: all
+debian_section: utils
+description: A self-hosted Bitwarden server
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Vaultwarden/icon.png
+license: Unknown
+long_description: Alternative implementation of the Bitwarden server API written in
+  Rust and compatible with upstream Bitwarden clients*, perfect for self-hosted deployment
+  where running the official resource-heavy service might not be ideal.
+maintainer: Daniel García <auto-converted@casaos.io>
+name: vaultwarden
+package_name: casaos-vaultwarden-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Vaultwarden/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Vaultwarden/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Vaultwarden/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/virt-manager/config.yml
+++ b/sources/casaos-official/apps/virt-manager/config.yml
@@ -1,0 +1,19 @@
+groups:
+- description: null
+  fields:
+  - default: 'false'
+    description: Set DARK_MODE to true to enable dark mode.
+    id: DARK_MODE
+    label: DARK_MODE
+    required: false
+    type: string
+  - default: '[''qemu:///system'']'
+    description: Set HOSTS to "['qemu:///session']" to connect to a user session.
+      Only change this option if you know what you're doing!
+    id: HOSTS
+    label: HOSTS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/virt-manager/docker-compose.yml
+++ b/sources/casaos-official/apps/virt-manager/docker-compose.yml
@@ -1,0 +1,21 @@
+name: virt-manager
+services:
+  virt-manager:
+    environment:
+      DARK_MODE: ${DARK_MODE}
+      HOSTS: ${HOSTS}
+    image: mber5/virt-manager:latest
+    ports:
+    - protocol: tcp
+      published: 8185
+      target: 80
+    volumes:
+    - source: /var/run/libvirt/libvirt-sock
+      target: /var/run/libvirt/libvirt-sock
+      type: bind
+    - source: /var/lib/libvirt
+      target: /var/lib/libvirt
+      type: bind
+    - source: /Downloads
+      target: /DATA/Downloads
+      type: bind

--- a/sources/casaos-official/apps/virt-manager/metadata.yaml
+++ b/sources/casaos-official/apps/virt-manager/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: utils
+description: A GTK Broadway web UI for libvirt and virt-manager.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VirtualMachineManager/icon.png
+license: Unknown
+long_description: A GTK Broadway web UI for libvirt and virt-manager, to run virtual
+  machines using QEMU/KVM.
+maintainer: Red Hat <auto-converted@casaos.io>
+name: virt-manager
+package_name: casaos-virt-manager-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VirtualMachineManager/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VirtualMachineManager/screenshot-2.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/vocechat/config.yml
+++ b/sources/casaos-official/apps/vocechat/config.yml
@@ -1,0 +1,12 @@
+groups:
+- description: null
+  fields:
+  - default: $TZ
+    description: TimeZone
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+version: '1.0'

--- a/sources/casaos-official/apps/vocechat/docker-compose.yml
+++ b/sources/casaos-official/apps/vocechat/docker-compose.yml
@@ -1,0 +1,14 @@
+name: vocechat
+services:
+  vocechat:
+    environment:
+      TZ: ${TZ}
+    image: privoce/vocechat-server:v0.3.33
+    ports:
+    - protocol: tcp
+      published: 3009
+      target: 3000
+    volumes:
+    - source: /AppData/$AppID/home/vocechat-server/data
+      target: /home/vocechat-server/data
+      type: bind

--- a/sources/casaos-official/apps/vocechat/metadata.yaml
+++ b/sources/casaos-official/apps/vocechat/metadata.yaml
@@ -1,0 +1,36 @@
+architecture: all
+debian_section: comm
+description: Have a Private Social Space Hosted on Your Site
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VoceChat/icon.png
+license: Unknown
+long_description: 'VoceChat is a secure chat software designed for independent deployment,
+  offering a flexible solution for seamless communication. It combines instant messaging
+  with channel-based group chats, allowing you to engage in one-on-one conversations
+  or create themed channels for group discussions.
+
+
+  VoceChat supports a variety of message formats, including text, images, files, emojis,
+  and rich text (Markdown), making your communication vibrant and expressive. Once
+  deployed, it can be accessed via a WebAPP or mobile APP, ensuring a consistent experience
+  across platforms.
+
+
+  With robust management features, VoceChat enables easy member and channel administration,
+  giving you full control over your team or group’s communication environment. Whether
+  for individual users or enterprise teams, VoceChat delivers a secure, versatile,
+  and efficient chat solution.
+
+  '
+maintainer: Privoce <auto-converted@casaos.io>
+name: vocechat
+package_name: casaos-vocechat-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VoceChat/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VoceChat/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VoceChat/screenshot-3.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/VoceChat/screenshot-4.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/wallabag/config.yml
+++ b/sources/casaos-official/apps/wallabag/config.yml
@@ -1,0 +1,18 @@
+groups:
+- description: null
+  fields:
+  - default: http://<IP>:25661
+    description: Instance domain name
+    id: SYMFONY__ENV__DOMAIN_NAME
+    label: SYMFONY__ENV__DOMAIN_NAME
+    required: false
+    type: string
+  - default: Wallabag
+    description: Server name
+    id: SYMFONY__ENV__SERVER_NAME
+    label: SYMFONY__ENV__SERVER_NAME
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/wallabag/docker-compose.yml
+++ b/sources/casaos-official/apps/wallabag/docker-compose.yml
@@ -1,0 +1,15 @@
+name: wallabag
+services:
+  wallabag:
+    environment:
+      SYMFONY__ENV__DOMAIN_NAME: ${SYMFONY__ENV__DOMAIN_NAME}
+      SYMFONY__ENV__SERVER_NAME: ${SYMFONY__ENV__SERVER_NAME}
+    image: wallabag/wallabag:2.6.13
+    ports:
+    - protocol: tcp
+      published: 25661
+      target: 80
+    volumes:
+    - source: /AppData/$AppID/images
+      target: /var/www/wallabag/web/assets/images
+      type: bind

--- a/sources/casaos-official/apps/wallabag/metadata.yaml
+++ b/sources/casaos-official/apps/wallabag/metadata.yaml
@@ -1,0 +1,71 @@
+architecture: all
+debian_section: text
+description: Save and classify articles. Read them later. Freely.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Wallabag/icon.png
+license: Unknown
+long_description: 'Wallabag is a web page saving app that allows users to save articles
+  for offline reading, extracting content for a distraction-free experience. Its intuitive
+  Web interface enables saving articles with a click, ensuring users can read them
+  at their convenience.
+
+
+  The app''s core features include convenient web page saving, optimized reading,
+  and flexible content organization. It extracts only the article''s content, removing
+  pop-ups and ads, and displays it in a clean, comfortable view. Users can organize
+  saved articles with tags and automatic tagging rules, creating a personalized content
+  library accessible on demand. Browser extensions enable quick saving, compatible
+  with Chrome, Firefox, Opera, and more. Cross-platform clients cover Android, iOS,
+  and other devices, ensuring a seamless reading experience. It also supports multi-user
+  collaboration for sharing saved articles.
+
+
+  It enables importing data from services like Pocket, Readability, Instapaper, or
+  Pinboard, simplifying content library migration. RSS generation allows users to
+  access saved articles in RSS readers. Community documentation enhances usability,
+  and the app''s high flexibility and intuitive operation deliver a modern web content
+  management solution.
+
+
+  **Key Features:**
+
+  - Save web pages for offline reading
+
+  - Extract pure content for a distraction-free reading view
+
+  - Article classification with automatic tagging rules for a personalized content
+  library
+
+  - Browser extensions for quick web page saving
+
+  - Cross-platform clients (Android, iOS, Chrome, Firefox, Opera)
+
+  - Multi-user collaboration for sharing saved articles
+
+  - Import data from Pocket, Readability, Instapaper, Pinboard and other services
+
+  - RSS generation for accessing saved articles in readers
+
+
+  **Learn More:**
+
+  - [Wallabag Official Website](https://wallabag.org)
+
+  - [Wallabag GitHub Repository](https://github.com/wallabag/wallabag)
+
+  - [Wallabag Documentation](https://doc.wallabag.org)
+
+  - [Wallabag Docker Image](https://hub.docker.com/r/wallabag/wallabag)
+
+  '
+maintainer: wallabag <auto-converted@casaos.io>
+name: wallabag
+package_name: casaos-wallabag-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Wallabag/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Wallabag/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Wallabag/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/webdav/config.yml
+++ b/sources/casaos-official/apps/webdav/config.yml
@@ -1,0 +1,46 @@
+groups:
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: GID
+    label: GID
+    max: 65535
+    min: 0
+    required: false
+    type: integer
+  - default: Europe/Madrid
+    description: ''
+    id: TZ
+    label: TZ
+    required: false
+    type: string
+  id: system
+  label: System Settings
+- description: null
+  fields:
+  - default: casaos
+    description: ''
+    id: PASSWORD
+    label: PASSWORD
+    required: false
+    type: password
+  - default: casaos
+    description: ''
+    id: USERNAME
+    label: USERNAME
+    required: false
+    type: string
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: '1000'
+    description: ''
+    id: UDI
+    label: UDI
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/webdav/docker-compose.yml
+++ b/sources/casaos-official/apps/webdav/docker-compose.yml
@@ -1,0 +1,18 @@
+name: webdav
+services:
+  webdav:
+    environment:
+      GID: ${GID}
+      PASSWORD: ${PASSWORD}
+      TZ: ${TZ}
+      UDI: ${UDI}
+      USERNAME: ${USERNAME}
+    image: ugeek/webdav:amd64
+    ports:
+    - protocol: tcp
+      published: 5005
+      target: 80
+    volumes:
+    - source: /media/ZimaOS-HD/Media
+      target: /media
+      type: bind

--- a/sources/casaos-official/apps/webdav/metadata.yaml
+++ b/sources/casaos-official/apps/webdav/metadata.yaml
@@ -1,0 +1,18 @@
+architecture: all
+debian_section: utils
+description: A web-based file sharing and management protocol
+homepage: null
+icon: https://icon.casaos.io/main/all/webdav.png
+license: Unknown
+long_description: WebDAV is a web-based protocol that allows you to share and manage
+  files over the internet, providing a collaborative environment for file editing
+  and versioning.
+maintainer: CasaOS Team <auto-converted@casaos.io>
+name: webdav
+package_name: casaos-webdav-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/WebDAV/screenshot-1.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/wg-easy/config.yml
+++ b/sources/casaos-official/apps/wg-easy/config.yml
@@ -1,0 +1,40 @@
+groups:
+- description: null
+  fields:
+  - default: casaos
+    description: ''
+    id: PASSWORD
+    label: PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+- description: null
+  fields:
+  - default: casaos.local
+    description: ''
+    id: WG_HOST
+    label: WG_HOST
+    required: false
+    type: string
+  - default: '51820'
+    description: ''
+    id: WG_PORT
+    label: WG_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: 1.1.1.1
+    description: ''
+    id: WG_DEFAULT_DNS
+    label: WG_DEFAULT_DNS
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+version: '1.0'

--- a/sources/casaos-official/apps/wg-easy/docker-compose.yml
+++ b/sources/casaos-official/apps/wg-easy/docker-compose.yml
@@ -1,0 +1,20 @@
+name: wg-easy
+services:
+  wg-easy:
+    environment:
+      PASSWORD: ${PASSWORD}
+      WG_DEFAULT_DNS: ${WG_DEFAULT_DNS}
+      WG_HOST: ${WG_HOST}
+      WG_PORT: ${WG_PORT}
+    image: ghcr.io/wg-easy/wg-easy:13
+    ports:
+    - protocol: udp
+      published: 51820
+      target: 51820
+    - protocol: tcp
+      published: 51821
+      target: 51821
+    volumes:
+    - source: /AppData/$AppID/wireguard
+      target: /etc/wireguard
+      type: bind

--- a/sources/casaos-official/apps/wg-easy/metadata.yaml
+++ b/sources/casaos-official/apps/wg-easy/metadata.yaml
@@ -1,0 +1,19 @@
+architecture: all
+debian_section: net
+description: WEB UI to manage WireGuard VPN.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/WireGuardEasy/icon.png
+license: Unknown
+long_description: You have found the easiest way to install & manage WireGuard on
+  any Linux host!
+maintainer: WeejeWel <auto-converted@casaos.io>
+name: wg-easy
+package_name: casaos-wg-easy-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/WireGuardEasy/screenshot-1.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/WireGuardEasy/screenshot-2.png
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/WireGuardEasy/screenshot-3.png
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0

--- a/sources/casaos-official/apps/ztnet/config.yml
+++ b/sources/casaos-official/apps/ztnet/config.yml
@@ -1,0 +1,88 @@
+groups:
+- description: null
+  fields:
+  - default: http://172.17.0.1:9993
+    description: ZeroTier controller address
+    id: ZT_ADDR
+    label: ZT_ADDR
+    required: false
+    type: string
+  - default: ztnet
+    description: PostgreSQL Database Name
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  - default: http://ztnet:3000
+    description: Server-side URL for NEXTAUTH
+    id: NEXTAUTH_URL_INTERNAL
+    label: NEXTAUTH_URL_INTERNAL
+    required: false
+    type: string
+  - default: ztnet
+    description: PostgreSQL Database Name
+    id: POSTGRES_DB
+    label: POSTGRES_DB
+    required: false
+    type: string
+  id: configuration
+  label: General Configuration
+- description: null
+  fields:
+  - default: ztnet-postgres
+    description: PostgreSQL Host
+    id: POSTGRES_HOST
+    label: POSTGRES_HOST
+    required: false
+    type: string
+  - default: '5432'
+    description: PostgreSQL Port
+    id: POSTGRES_PORT
+    label: POSTGRES_PORT
+    max: 65535
+    min: 1024
+    required: false
+    type: integer
+  - default: http://0.0.0.0:3050
+    description: Canonical URL of your site
+    id: NEXTAUTH_URL
+    label: NEXTAUTH_URL
+    required: false
+    type: string
+  id: network
+  label: Network Settings
+- description: null
+  fields:
+  - default: ztnet
+    description: PostgreSQL User
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: ztnetbl5hbv98wl89x9v
+    description: PostgreSQL Password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  - default: mn6vor005ncgnu9iuqxn8bg
+    description: NextAuth Secret Key
+    id: NEXTAUTH_SECRET
+    label: NEXTAUTH_SECRET
+    required: false
+    type: password
+  - default: ztnet
+    description: PostgreSQL User
+    id: POSTGRES_USER
+    label: POSTGRES_USER
+    required: false
+    type: string
+  - default: ztnetbl5hbv98wl89x9v
+    description: PostgreSQL Password
+    id: POSTGRES_PASSWORD
+    label: POSTGRES_PASSWORD
+    required: false
+    type: password
+  id: authentication
+  label: Authentication
+version: '1.0'

--- a/sources/casaos-official/apps/ztnet/docker-compose.yml
+++ b/sources/casaos-official/apps/ztnet/docker-compose.yml
@@ -1,0 +1,32 @@
+name: ztnet
+services:
+  ztnet:
+    environment:
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      NEXTAUTH_URL: ${NEXTAUTH_URL}
+      NEXTAUTH_URL_INTERNAL: ${NEXTAUTH_URL_INTERNAL}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_USER: ${POSTGRES_USER}
+      ZT_ADDR: ${ZT_ADDR}
+    image: sinamics/ztnet:0.7.5
+    ports:
+    - protocol: tcp
+      published: 3050
+      target: 3000
+    volumes:
+    - source: /var/lib/zerotier-one
+      target: /var/lib/zerotier-one
+      type: bind
+  ztnet-postgres:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+    image: postgres:15.2-alpine
+    volumes:
+    - source: /AppData/$AppID/postgres-data
+      target: /var/lib/postgresql/data
+      type: bind

--- a/sources/casaos-official/apps/ztnet/metadata.yaml
+++ b/sources/casaos-official/apps/ztnet/metadata.yaml
@@ -1,0 +1,66 @@
+architecture: all
+debian_section: net
+description: Self-hosted ZeroTier network controller with web UI for centralized management.
+homepage: null
+icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/icon.png
+license: Unknown
+long_description: 'ZTNET is a powerful ZeroTier network management tool that simplifies
+  network configuration and management through an intuitive Web interface, ideal for
+  teams and individual users. Its modern design and rich features provide an efficient
+  solution for building secure, scalable virtual networks.
+
+
+  The tool centers on an intuitive Web interface and organization with multi-user
+  support. Developed in TypeScript, it acts as an intermediary between users and the
+  ZeroTier Controller API, enabling collaborative network management within organizations
+  to streamline team tasks. Integration with ZeroTier Central API allows direct management
+  of networks, nodes, and members through a user-friendly interface, enhancing configuration
+  efficiency.
+
+
+  It supports custom private root servers to create isolated network environments,
+  improving privacy and control. Personalized user spaces enable users to independently
+  create and manage networks. Support for 6plane and rfc4193 IPv6 addressing enriches
+  enterprise or personal networking capabilities. Compatibility with ARM64 and AMD64
+  architectures ensures broad device support. The tool focuses on user-friendly and
+  flexible design to deliver a modern network management experience.
+
+
+  **Key Features:**
+
+  - Intuitive Web interface for simplified ZeroTier network management
+
+  - Organization and multi-user support for team collaboration
+
+  - Integration with ZeroTier Central API for managing networks and nodes
+
+  - Custom private root server for enhanced privacy and control
+
+  - Personalized user spaces for independent network creation and management
+
+  - Support for 6plane and rfc4193 IPv6 addressing
+
+  - Compatibility with ARM64 and AMD64 architectures for diverse devices
+
+
+  **Learn More:**
+
+  - [ZTnet Official Website](https://ztnet.network/)
+
+  - [ZTnet GitHub](https://github.com/sinamics/ztnet)
+
+  '
+maintainer: sinamics <auto-converted@casaos.io>
+name: ztnet
+package_name: casaos-ztnet-container
+screenshots:
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-1.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-2.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-3.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-4.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-5.jpg
+- https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Ztnet/screenshot-6.jpg
+source_metadata: null
+tags:
+- role::container-app
+version: 1.0.0


### PR DESCRIPTION
## Summary

Adds all 147 converted CasaOS applications to the repository, completing Issue #12.

## Changes

### Issue #12: Convert CasaOS apps to HaLOS format ✅

- **Added 147 apps** from CasaOS Official App Store
- Each app includes:
  - `metadata.yaml` - Package metadata (name, description, version, license)
  - `config.yml` - User-configurable parameters schema
  - `docker-compose.yml` - Container service definition
- **Conversion success rate**: 147/147 (100%)
- **Total size**: 1.8MB (441 files)

### Apps Included

Notable applications:
- **Media Servers**: Plex, Jellyfin, Emby, Navidrome
- **Home Automation**: Home Assistant, Node-RED, ESPHome, Homebridge
- **Networking**: Pi-hole, AdGuard Home, WireGuard, Nginx Proxy Manager
- **Development**: Gitea, Jenkins, n8n, Portainer
- **AI/ML**: Ollama, Open WebUI, Flowise, Dify
- **Storage**: Nextcloud, Syncthing, Resilio Sync
- **Download Managers**: qBittorrent, Transmission, Deluge, SABnzbd
- **Media Management**: Sonarr, Radarr, Lidarr, Prowlarr, Bazarr
- **Monitoring**: Grafana, Netdata, Glances, Uptime Kuma
- And 120+ more applications across various categories

### Conversion Process

Apps were converted using `container-packaging-tools` v0.2.0:
- Source: [CasaOS-AppStore](https://github.com/IceWhaleTech/CasaOS-AppStore)
- Converter: CasaOS format v2.0
- Method: Batch conversion with intelligent fallbacks
- Package naming: `casaos-{appname}-container` (all lowercase)

### Note on Issue #11

Issue #11 (create store package) was already completed in PR #27. The store package infrastructure is already in place at:
- `sources/casaos-official/store/casaos-official.yaml`
- `sources/casaos-official/store/debian/`

### Note on Issue #13

Issue #13 (test full build) is deferred. The build scripts currently have placeholders and need to be updated to actually use `container-packaging-tools` for building packages. This will be addressed separately.

### Security Note

Replaced example API key placeholders in `dify/config.yml` that triggered GitHub's secret scanning. These were not real secrets, just upstream placeholders.

## Testing

- ✅ All 147 apps copied successfully
- ✅ File structure validated (metadata.yaml, config.yml, docker-compose.yml per app)
- ✅ Total file count correct (441 files = 147 apps × 3 files)
- ⚠️ Build testing pending (Issue #13)

## References

- Closes #12
- Related: #11 (already closed in PR #27)
- Related: #13 (deferred - requires build script updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
