### PR TITLE
fix(workflow): add checkout step to publish-unstable job

### DIFF
--- a/.github/workflows/main-casaos.yml
+++ b/.github/workflows/main-casaos.yml
@@ -69,6 +69,9 @@ jobs:
     # At that point, the build job will always produce packages and this job should always run.
     if: needs.build.outputs.has-packages == 'true'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem

The main-casaos workflow failed when PR #34 was merged:

**Error**: `fatal: not a git repository (or any of the parent directories): .git`

**Failed run**: https://github.com/hatlabs/halos-imported-containers/actions/runs/19799453845/job/56724923250

The `publish-unstable` job was trying to run `git fetch --tags --quiet` to generate release tags, but failed because no git repository was checked out.

## Root Cause

The `publish-unstable` job has these steps:
1. Download build artifacts ✓
2. List packages ✓
3. **Generate release tag** ✗ - runs `git fetch --tags` but no checkout
4. Create pre-release (not reached)
5. Dispatch to APT repo (not reached)

The job downloads artifacts but never checks out the repository, so git commands fail.

## Solution

Add a checkout step at the beginning of the `publish-unstable` job, before downloading artifacts:

```yaml
steps:
  - name: Checkout code
    uses: actions/checkout@v4

  - name: Download build artifacts
    # ... rest of steps
```

This gives the job access to the git repository so it can fetch tags and generate release tags.

## Testing

The PR checks will validate the workflow syntax. After merge, the next push to main will test the full workflow end-to-end.

## Related

- Fixes the failure from PR #34 merge
- Unblocks issue #19 (package publishing)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)