### PR TITLE
Fix APT dispatch target: hatlabs/apt.hatlabs.fi → halos-org/apt.halos.fi

### DIFF
--- a/.github/workflows/main-casaos.yml
+++ b/.github/workflows/main-casaos.yml
@@ -118,14 +118,14 @@ jobs:
             ### Packages
 
             This release contains Debian packages for all CasaOS apps.
-            These packages are automatically published to apt.hatlabs.fi unstable channel.
+            These packages are automatically published to apt.halos.fi unstable channel.
 
             ### Installation
 
             ```bash
             # Add HaLOS APT repository (if not already added)
-            curl -fsSL https://apt.hatlabs.fi/halos-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/halos-archive-keyring.gpg
-            echo "deb [signed-by=/usr/share/keyrings/halos-archive-keyring.gpg] https://apt.hatlabs.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos-unstable.list
+            curl -fsSL https://apt.halos.fi/halos-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/halos-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/halos-archive-keyring.gpg] https://apt.halos.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos-unstable.list
 
             # Update and install
             sudo apt update
@@ -139,7 +139,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           client-payload: |
             {
@@ -159,5 +159,5 @@ jobs:
           echo "Channel: unstable"
           echo "Component: main"
           echo ""
-          echo "Dispatched to hatlabs/apt.hatlabs.fi"
-          echo "Packages will be available via apt.hatlabs.fi unstable channel"
+          echo "Dispatched to halos-org/apt.halos.fi"
+          echo "Packages will be available via apt.halos.fi unstable channel"

--- a/.github/workflows/release-casaos.yml
+++ b/.github/workflows/release-casaos.yml
@@ -84,7 +84,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           client-payload: |
             {
@@ -104,6 +104,6 @@ jobs:
           echo "Channel: stable"
           echo "Component: main"
           echo ""
-          echo "Dispatched to hatlabs/apt.hatlabs.fi"
-          echo "Packages will be available via apt.hatlabs.fi stable channel"
+          echo "Dispatched to halos-org/apt.halos.fi"
+          echo "Packages will be available via apt.halos.fi stable channel"
           echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Apps are automatically converted using the [`container-packaging-tools`](https:/
 1. **Upstream Sync**: Monitor multiple upstream app stores for changes
 2. **Automatic Conversion**: Run source-specific converters on all apps (currently 144/144 for CasaOS)
 3. **Package Generation**: Build Debian packages with proper metadata and source prefixes
-4. **Repository Publishing**: Publish to apt.hatlabs.fi
+4. **Repository Publishing**: Publish to apt.halos.fi
 
 ## Package Format
 

--- a/docs/ADDING_SOURCES.md
+++ b/docs/ADDING_SOURCES.md
@@ -451,7 +451,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           client-payload: |
             {
@@ -521,7 +521,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           client-payload: |
             {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,7 +45,7 @@ This design enables:
 
 **Build System** processes converted apps and store definitions to create Debian packages. The build process is source-aware, applying correct naming prefixes and dependencies.
 
-**APT Repository** (apt.hatlabs.fi) receives packages through the CI/CD pipeline, making them available for installation on HaLOS systems via standard APT mechanisms.
+**APT Repository** (apt.halos.fi) receives packages through the CI/CD pipeline, making them available for installation on HaLOS systems via standard APT mechanisms.
 
 **Cockpit UI** discovers stores through installed store packages and filters apps based on package name patterns defined in each store's configuration.
 
@@ -143,7 +143,7 @@ Upstream source configuration defines sync behavior:
 - **Debian Packaging**: Standard .deb package format for distribution. Uses dpkg-buildpackage, debhelper, and dh-python.
 - **Python 3.11+**: Runtime for container-packaging-tools and build scripts. Uses uv for dependency management.
 - **Docker**: Required at runtime for container execution. Not used in build process.
-- **APT Repository**: Custom repository at apt.hatlabs.fi for package distribution.
+- **APT Repository**: Custom repository at apt.halos.fi for package distribution.
 
 ### Build Tools
 
@@ -192,7 +192,7 @@ Packages are published through:
 - **Unstable channel**: Automatic on merge to main branch via repository_dispatch
 - **Stable channel**: Manual via GitHub release creation and repository_dispatch
 - **Repository structure**: Organized by distribution (trixie) and component (main)
-- **Authentication**: GitHub PAT (APT_REPO_PAT) with write access to apt.hatlabs.fi repository
+- **Authentication**: GitHub PAT (APT_REPO_PAT) with write access to apt.halos.fi repository
 
 ### Cockpit UI Integration
 
@@ -330,13 +330,13 @@ The repository uses per-source workflows for build isolation. Each source has it
 The main-casaos.yml workflow:
 - Builds packages using repository-specific actions
 - Creates pre-release directly via GitHub API
-- Triggers repository_dispatch to apt.hatlabs.fi for package publishing
+- Triggers repository_dispatch to apt.halos.fi for package publishing
 - Includes all publishing logic inline for transparency and debugging
 
 The release-casaos.yml workflow:
 - Builds packages for stable release
 - Creates GitHub release directly
-- Triggers repository_dispatch to apt.hatlabs.fi for stable channel publishing
+- Triggers repository_dispatch to apt.halos.fi for stable channel publishing
 
 **Benefits of Inline Publishing**:
 - Complete control over publishing process
@@ -378,7 +378,7 @@ The release-casaos.yml workflow:
 
 ### Secrets and Configuration
 
-**APT_REPO_PAT**: GitHub personal access token with write access to apt.hatlabs.fi repository (shared across all source workflows)
+**APT_REPO_PAT**: GitHub personal access token with write access to apt.halos.fi repository (shared across all source workflows)
 
 **Per-Source Workflow Configuration**:
 - apt-distro: trixie (Debian 13)
@@ -444,7 +444,7 @@ All packages include:
 - **Upstream URL**: Link back to original upstream definition
 - **License information**: Recorded from upstream metadata
 - **Maintainer**: Hat Labs as package maintainer
-- **Signature**: APT repository signing (handled by apt.hatlabs.fi)
+- **Signature**: APT repository signing (handled by apt.halos.fi)
 
 ### Upstream Trust
 
@@ -511,7 +511,7 @@ Build resource usage:
 - **GitHub Actions minutes**: ~5-10 minutes per source build, runs in parallel across sources
 - **Selective triggering**: Path filtering means only changed sources consume CI minutes
 - **Storage**: Build artifacts cleaned after upload
-- **APT repository size**: Grows with number of packages (managed by apt.hatlabs.fi)
+- **APT repository size**: Grows with number of packages (managed by apt.halos.fi)
 - **Network**: Minimal during build, higher during upstream sync
 - **Parallel efficiency**: Multiple sources building simultaneously doesn't increase wall-clock time
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -100,7 +100,7 @@ The multi-source architecture allows each source to maintain its own identity, v
 
 ### 4. Repository Publication
 
-**Feature**: Publish packages to apt.hatlabs.fi APT repository
+**Feature**: Publish packages to apt.halos.fi APT repository
 
 **Behavior**:
 - Push to unstable channel on merge to main
@@ -173,7 +173,7 @@ The multi-source architecture allows each source to maintain its own identity, v
 
 1. **Git Repository**: Private repository in hatlabs organization
 2. **GitHub Actions**: Standard CI/CD workflows for PR, main, release
-3. **APT Repository**: Integration with apt.hatlabs.fi
+3. **APT Repository**: Integration with apt.halos.fi
 4. **Docker**: Build environment requires Docker support
 
 ## Key Constraints and Assumptions

--- a/sources/_template/.github/README.md
+++ b/sources/_template/.github/README.md
@@ -114,7 +114,7 @@ yamllint .github/workflows/release-runtipi.yml
 
 **Publishing**:
 - Creates GitHub pre-release with tag format `YYYY-MM-DD+N`
-- Dispatches to `hatlabs/apt.hatlabs.fi` repository (unstable channel)
+- Dispatches to `halos-org/apt.halos.fi` repository (unstable channel)
 - Requires `APT_REPO_PAT` secret
 
 ### Release Workflow (`release-{source}.yml`)
@@ -135,7 +135,7 @@ yamllint .github/workflows/release-runtipi.yml
 
 **Publishing**:
 - Attaches .deb packages to GitHub release
-- Dispatches to `hatlabs/apt.hatlabs.fi` repository (stable channel)
+- Dispatches to `halos-org/apt.halos.fi` repository (stable channel)
 - Requires `APT_REPO_PAT` secret
 
 ## Placeholders Reference
@@ -194,7 +194,7 @@ The workflows require the following repository secret:
 
 ### APT_REPO_PAT
 
-**Purpose**: GitHub Personal Access Token with write access to `hatlabs/apt.hatlabs.fi` repository
+**Purpose**: GitHub Personal Access Token with write access to `halos-org/apt.halos.fi` repository
 
 **Used by**:
 - `main-{source}.yml` (publish-unstable job)
@@ -287,7 +287,7 @@ Before merging workflows for a new source:
 
 **Check**:
 - `APT_REPO_PAT` secret is configured in repository settings
-- PAT has write access to `hatlabs/apt.hatlabs.fi` repository
+- PAT has write access to `halos-org/apt.halos.fi` repository
 - PAT has not expired
 
 ### Release workflow doesn't trigger

--- a/sources/_template/.github/workflows/main-{source}.yml.template
+++ b/sources/_template/.github/workflows/main-{source}.yml.template
@@ -161,14 +161,14 @@ jobs:
             ### Packages
 
             This release contains Debian packages for all {SOURCE_DISPLAY_NAME} apps.
-            These packages are automatically published to apt.hatlabs.fi unstable channel.
+            These packages are automatically published to apt.halos.fi unstable channel.
 
             ### Installation
 
             ```bash
             # Add HaLOS APT repository (if not already added)
-            curl -fsSL https://apt.hatlabs.fi/halos-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/halos-archive-keyring.gpg
-            echo "deb [signed-by=/usr/share/keyrings/halos-archive-keyring.gpg] https://apt.hatlabs.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos-unstable.list
+            curl -fsSL https://apt.halos.fi/halos-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/halos-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/halos-archive-keyring.gpg] https://apt.halos.fi trixie-unstable main" | sudo tee /etc/apt/sources.list.d/halos-unstable.list
 
             # Update and install
             sudo apt update
@@ -180,14 +180,14 @@ jobs:
           fail_on_unmatched_files: true  # Fail if no files found
 
       # STEP: Dispatch to APT repository
-      # Sends event to apt.hatlabs.fi repository to trigger package import
+      # Sends event to apt.halos.fi repository to trigger package import
       # APT repository will download packages from this release and add them
       - name: Dispatch to APT repository
         uses: peter-evans/repository-dispatch@v3
         with:
           # REQUIRED: Update APT_REPO_PAT secret in repository settings
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           # Payload tells APT repo what to import and where
           client-payload: |
@@ -209,5 +209,5 @@ jobs:
           echo "Channel: unstable"
           echo "Component: main"
           echo ""
-          echo "Dispatched to hatlabs/apt.hatlabs.fi"
-          echo "Packages will be available via apt.hatlabs.fi unstable channel"
+          echo "Dispatched to halos-org/apt.halos.fi"
+          echo "Packages will be available via apt.halos.fi unstable channel"

--- a/sources/_template/.github/workflows/release-{source}.yml.template
+++ b/sources/_template/.github/workflows/release-{source}.yml.template
@@ -123,7 +123,7 @@ jobs:
           ls -lh build/*.deb
 
       # STEP: Dispatch to APT repository
-      # Sends event to apt.hatlabs.fi repository to trigger package import
+      # Sends event to apt.halos.fi repository to trigger package import
       # Only runs if packages exist
       - name: Dispatch to APT repository
         if: steps.check.outputs.has-packages == 'true'
@@ -131,7 +131,7 @@ jobs:
         with:
           # REQUIRED: Ensure APT_REPO_PAT secret is configured in repository settings
           token: ${{ secrets.APT_REPO_PAT }}
-          repository: hatlabs/apt.hatlabs.fi
+          repository: halos-org/apt.halos.fi
           event-type: package-updated
           # Payload tells APT repo what to import and where
           client-payload: |
@@ -154,6 +154,6 @@ jobs:
           echo "Channel: stable"
           echo "Component: main"
           echo ""
-          echo "Dispatched to hatlabs/apt.hatlabs.fi"
-          echo "Packages will be available via apt.hatlabs.fi stable channel"
+          echo "Dispatched to halos-org/apt.halos.fi"
+          echo "Packages will be available via apt.halos.fi stable channel"
           echo "Release URL: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}"

--- a/sources/_template/README.md.template
+++ b/sources/_template/README.md.template
@@ -66,7 +66,7 @@ The automated sync workflow will:
 4. **PR Creation**: Create pull request with converted apps
 5. **Validation**: CI validates all converted app definitions
 6. **Merge**: After approval, merge triggers package builds
-7. **Publication**: Packages published to apt.hatlabs.fi
+7. **Publication**: Packages published to apt.halos.fi
 
 ## Conversion Details
 
@@ -123,7 +123,7 @@ All packages clearly indicate their source:
 - **Upstream**: [{UPSTREAM_NAME}]({UPSTREAM_URL})
 - **Converter**: [container-packaging-tools](https://github.com/halos-org/container-packaging-tools)
 - **Repository**: [halos-imported-containers](https://github.com/halos-org/halos-imported-containers)
-- **APT Repository**: [apt.hatlabs.fi](https://apt.hatlabs.fi)
+- **APT Repository**: [apt.halos.fi](https://apt.halos.fi)
 
 ## License
 

--- a/sources/casaos/README.md
+++ b/sources/casaos/README.md
@@ -66,7 +66,7 @@ The automated sync workflow will:
 4. **PR Creation**: Create pull request with converted apps
 5. **Validation**: CI validates all converted app definitions
 6. **Merge**: After approval, merge triggers package builds
-7. **Publication**: Packages published to apt.hatlabs.fi
+7. **Publication**: Packages published to apt.halos.fi
 
 ## Conversion Details
 
@@ -129,7 +129,7 @@ All packages clearly indicate their source:
 - **Upstream**: [CasaOS-AppStore](https://github.com/IceWhaleTech/CasaOS-AppStore)
 - **Converter**: [container-packaging-tools](https://github.com/halos-org/container-packaging-tools)
 - **Repository**: [halos-imported-containers](https://github.com/halos-org/halos-imported-containers)
-- **APT Repository**: [apt.hatlabs.fi](https://apt.hatlabs.fi)
+- **APT Repository**: [apt.halos.fi](https://apt.halos.fi)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Fix workflow dispatch target from `hatlabs/apt.hatlabs.fi` to `halos-org/apt.halos.fi` in both `main-casaos.yml` and `release-casaos.yml`
- Update all docs, templates, and READMEs to reference `apt.halos.fi` instead of `apt.hatlabs.fi`

The PAT cannot access `hatlabs/apt.hatlabs.fi` from `halos-org`, causing `Resource not accessible by personal access token` on every main branch build since the org migration.

## Test plan

- [ ] After merge, main branch CI/CD succeeds (dispatch step no longer fails)
- [ ] Verify APT_REPO_PAT secret has access to `halos-org/apt.halos.fi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)